### PR TITLE
Add missing guide name to permalinks for agile pages

### DIFF
--- a/content/agile/agile-is-something-you-are-not-something-you-do.md
+++ b/content/agile/agile-is-something-you-are-not-something-you-do.md
@@ -1,6 +1,6 @@
 ---
 title: Agile is something you are, not something you do
-permalink: /agile-is-something-you-are/
+permalink: /agile/agile-is-something-you-are/
 layout: layouts/page
 sidenav: true
 tags: agile

--- a/content/agile/agile-lexicon.md
+++ b/content/agile/agile-lexicon.md
@@ -1,6 +1,6 @@
 ---
 title:  Agile lexicon
-permalink: /agile-lexicon/
+permalink: /agile/agile-lexicon/
 layout: layouts/page
 sidenav: true
 tags: agile


### PR DESCRIPTION
## Changes proposed in this pull request:
This PR updates the permalink for a couple of pages in the agile guide that didn't have the `agile` guide name in the base of the permalink. This brings it in with the pattern we have established for the all of guides. 

👓 [Preview](https://federalist-8bc0b42c-5fd0-4ae8-9366-cd9c265a4446.sites.pages.cloud.gov/preview/18f/guides/ik/fix-agile-urls/agile/agile-is-something-you-are/) 