### PR TITLE
Add site alert about url change

### DIFF
--- a/_includes/layouts/base.html
+++ b/_includes/layouts/base.html
@@ -8,8 +8,8 @@ The home page uses wide.html layout, since it extends full width of page
 {% include "meta.html" %}
 
 <body>
+  {% include "site-alert.html" %}
   {% include "header.html" %}
-
   {% if tags %} 
     {% assign primary_navigation = navigation[tags] %}
   {% else %} 

--- a/_includes/site-alert.html
+++ b/_includes/site-alert.html
@@ -1,0 +1,9 @@
+<section aria-label="Alert">
+  <div class="usa-alert usa-alert--warning usa-alert--no-icon">
+    <div class="usa-alert__body">
+      <p class="usa-alert__text">
+        We are in the process of moving all of the 18F guides to a new url. You can still find all 18F guides at <a href="https://18f.gsa.gov/guides">18f.gsa.gov/guides</a>.
+      </p>
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
## Changes proposed in this pull request:
This PR adds a site-wide alert banner that informs visitors about changing URLs for the 18F guides. 

Closes [TLC/451](https://github.com/18F/TLC-crew/issues/451)

👓 [Preview](https://federalist-8bc0b42c-5fd0-4ae8-9366-cd9c265a4446.sites.pages.cloud.gov/preview/18f/guides/ik/url-banner/)