### PR TITLE
Change references to Approaches to Guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 18F approaches
+# 18F Guides
 
 A work in progress repository for consolidating the 18F Guides and Methods
 

--- a/_data/site.yaml
+++ b/_data/site.yaml
@@ -1,4 +1,4 @@
-title: 18F Approaches
+title: 18F Guides
 description: >- # this means to ignore newlines
   A central resources for all 18F guides and methods
 

--- a/_data/titles_roots.yaml
+++ b/_data/titles_roots.yaml
@@ -1,6 +1,6 @@
 # Title for each guide that will appear in the header, as well as the root subdirectory for the guide
 default:
-  title: 18F Approaches
+  title: Guides
   root: /
 accessibility:
   title: Accessibility


### PR DESCRIPTION
## Changes proposed in this pull request:
This PR updates the default guide name to be "Guides" instead of 18F Approaches. This is noticeable on the home page and on the 404 page. Updated references in the config and README files as well. Closes #97 

👓 [Preview](https://federalist-8bc0b42c-5fd0-4ae8-9366-cd9c265a4446.sites.pages.cloud.gov/preview/18f/guides/ik/change-default-names/) 
