### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,21 +14,24 @@
 
 # Unless another rule applies below, request review from someone on the TLC crew 
 # or the Chief of Delivery.
-* @18F/18f-tlc-crew @adunkman
+* @18F/18f-tlc-crew # @adunkman
 
 # Guides are currently organized by general topic area, and content approvals are 
 # delegated to relevant subject matter experts.
 
-/content/accessibility/**/*.md   @jasnakai
-/content/agile/**/*.md           @adunkman
-/content/brand/**/*.md           @igorkorenfeld
-/content/content-guide/**/*.md   @michelle-rago
-/content/derisking/**/*.md       @adunkman
-/content/design/**/*.md          @MelissaBraxton
-/content/eng-hiring/**/*.md      @amymok
-/content/engineering/**/*.md     @amymok
-/content/product/**/*.md         @allisonnorman
-/content/ux-guide/**/*.md        @juliaklindpaintner
+# Oct 2023: Commenting these out while we replatform
+# https://github.com/18F/guides/pull/65#issuecomment-1783084851
+
+# /content/accessibility/**/*.md   @jasnakai
+# /content/agile/**/*.md           @adunkman
+# /content/brand/**/*.md           @igorkorenfeld
+# /content/content-guide/**/*.md   @michelle-rago
+# /content/derisking/**/*.md       @adunkman
+# /content/design/**/*.md          @MelissaBraxton
+# /content/eng-hiring/**/*.md      @amymok
+# /content/engineering/**/*.md     @amymok
+# /content/product/**/*.md         @allisonnorman
+# /content/ux-guide/**/*.md        @juliaklindpaintner
 
 # The pull request template and CODEOWNERS files should be reviewed by the Chief of Delivery;
 # placed at the end of the file to ensure they are not overridden by another rule.


### PR DESCRIPTION
Comment out default reviewers for guides given replatforming efforts currently underway, as suggested in https://github.com/18F/guides/pull/65#issuecomment-1783084851.

## Changes proposed in this pull request:

- Comments out default content reviewers to reduce pull request noise.

## Security considerations

No considerations.
