### PR TITLE
Proposal: Silence no-console warn from buildAssets.js

### DIFF
--- a/config/buildAssets.js
+++ b/config/buildAssets.js
@@ -1,5 +1,9 @@
 /* eslint no-restricted-syntax: 0 no-shadow: 0 */
 /** eslint doesn't like iterators/generators */
+
+/* eslint-disable no-console */
+/** we are using console.logs for logging asset builds */
+
 const fs = require('fs/promises');
 const path = require('path');
 const esbuild = require('esbuild');
@@ -89,11 +93,10 @@ esbuild
   })
   .then(() => createAssetPaths())
   .then(() => {
-    process.stdout.write('Assets have been built!\n');
+    console.log('Assets have been built!');
     process.exit();
   })
   .catch((err) => {
-    process.stderr.write(err);
-    process.stderr.write('\n');
+    console.error(err);
     process.exit(1);
   });

--- a/config/buildAssets.js
+++ b/config/buildAssets.js
@@ -1,7 +1,6 @@
-/* eslint no-restricted-syntax: 0 no-shadow: 0 */
+/* eslint no-restricted-syntax: 0, no-shadow: 0, no-console: 0 */
 /** eslint doesn't like iterators/generators */
 
-/* eslint-disable no-console */
 /** we are using console.logs for logging asset builds */
 
 const fs = require('fs/promises');

--- a/config/buildAssets.js
+++ b/config/buildAssets.js
@@ -89,10 +89,11 @@ esbuild
   })
   .then(() => createAssetPaths())
   .then(() => {
-    console.log('Assets have been built!');
+    process.stdout.write('Assets have been built!\n');
     process.exit();
   })
   .catch((err) => {
-    console.error(err);
+    process.stderr.write(err);
+    process.stderr.write('\n');
     process.exit(1);
   });

--- a/config/buildAssets.js
+++ b/config/buildAssets.js
@@ -1,4 +1,4 @@
-/* eslint no-restricted-syntax: 0, no-shadow: 0, no-console: 0 */
+/* eslint no-restricted-syntax: 'off', no-shadow: 'off', no-console: 'off' */
 /** eslint doesn't like iterators/generators */
 
 /** we are using console.logs for logging asset builds */


### PR DESCRIPTION
## Changes proposed in this pull request:

A tiny proposal to change the `console.log` in the esbuild config to a write to `stdout`/`stderr` to avoid triggering the eslint warning – since that will happen on every PR and run of the linter. 

