### PR TITLE
Fully-qualified URLs in production sitemap

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -15,6 +15,8 @@ const yaml = require("js-yaml");
 
 const { imageShortcode, imageWithClassShortcode } = require('./config');
 
+const siteData = yaml.load(fs.readFileSync('./_data/site.yaml', 'utf8'));
+
 module.exports = function (config) {
   // Set pathPrefix for site
   let pathPrefix = '/';
@@ -72,6 +74,12 @@ module.exports = function (config) {
   // Color contrast checkers for the color matrix in the Brand guide
   config.addFilter('contrastRatio', contrastRatio);
   config.addFilter('humanReadableContrastRatio', humanReadableContrastRatio);
+
+  // Create absolute urls
+  config.addFilter('asAbsoluteUrl', (relativeUrl) => {
+    const host = siteData.host;
+    return new URL(relativeUrl, host).href;
+  });
 
   // Create an array of all tags
   config.addCollection('tagList', function (collection) {

--- a/sitemap.xml.njk
+++ b/sitemap.xml.njk
@@ -4,13 +4,17 @@ eleventyExcludeFromCollections: true
 ---
 <?xml version="1.0" encoding="utf-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-{%- for page in collections.all %}
-  {% if page.url %}
-    {% set absoluteUrl %}{{ page.url | url | absoluteUrl }}{% endset %}
-    <url>
-      <loc>{{ absoluteUrl }}</loc>
-      <lastmod>{{ page.date | htmlDateString }}</lastmod>
-    </url>
-  {% endif %}
-{%- endfor %}
+  {%- for page in collections.all %}
+    {%- if page.url %}
+      {%- set renderedUrl %}{{ page.url | url }}{%- endset %}
+      <url>
+        {%- if env.production %}
+          <loc>{{ renderedUrl | asAbsoluteUrl }}</loc>
+        {%- else %}
+          <loc>{{ renderedUrl }}</loc>
+        {%- endif %}
+        <lastmod>{{ page.date | htmlDateString }}</lastmod>
+      </url>
+    {%- endif %}
+  {%- endfor %}
 </urlset>


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adding `asAbsoluteUrl` filter for prepending the site hostname to a given url
- Ensuring that the sitemap renders fully-qualified URLs when in production, as defined by our env.js file

## Purpose
Search.gov requires fully-qualified URLs in order to properly index the site.

## security considerations
No known concerns