### PR TITLE
Re-activating search bar and updating config

### DIFF
--- a/_data/site.yaml
+++ b/_data/site.yaml
@@ -26,17 +26,17 @@ searchgov:
   endpoint: https://search.usa.gov
 
   # Replace this with your search.gov account.
-  affiliate: federalist-uswds-example
+  affiliate: 18f-guides
 
   # Replace this with your access key.
-  access_key: xX1gtb2RcnLbIYkHAcB6IaTRr4ZfN-p16ofcyUebeko=
+  access_key: empty
 
   # This renders the results within the page instead of sending to user to search.gov.
-  inline: true
+  inline: false
 
   # This allows Search.gov to present relevant type-ahead search suggestions in your website's search box.
   # If you do not want to present search suggestions, set this value to false.
-  suggestions: true
+  suggestions: false
 
 ##########################################################################################
 # The values below here are more advanced and should only be

--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -73,10 +73,7 @@ manage your navigation system {% endcomment %}
           {% endfor %}
         </ul>
         {% endif %}
-        {% comment %}
-          TODO re-enable search by uncommenting:
-          {% include "searchgov/form.html" searchgov: site.searchgov %}
-        {% endcomment %}
+        {% include "searchgov/form.html" searchgov: site.searchgov %}
       </div>
     </div>
   </nav>


### PR DESCRIPTION
## Changes proposed in this pull request:

- Reactivate the search bar, which will only appear in the currently replatformed guides (only agile as of this writing)
- Update the site's search config in the site.yaml file

## security considerations
No known concerns
  
## To test
- Start the environment locally or test in the Cloud Pages build for this branch
- Enter a search term like "agile" or "testing" into the search bar at top right of the [agile guide](http://localhost:8080/agile/)
- Ensure the following:
  - There are results from `guides.18f.gov/agile`
  - There are NOT results from other `guides.18f.gov/<guide-name>` guides
  - It is OK if there are also results from `methods.18f.gov` for now 
  
## Closes
#114 
