### PR TITLE
Add approve pr step to dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -17,7 +17,9 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Enable auto-merge for Dependabot PRs
         if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: |
+          gh pr review --approve
+          gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Because we require 1 approving review in order for any PR to be merged, we need to "approve" the dependabot patch PR's before auto-merging them

## security considerations

If set up incorrectly, this could allow other unintended types of PR's to auto-merge. 

This PR does **not** change the conditional that checks for the types of PR's we want to auto-merge:
```
if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
```
Since we've confirmed that this conditional is working as expected, the above risk is mitigated. 
