### PR TITLE
Ensure other checks pass before running dependabot auto-merge action

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -7,6 +7,7 @@ permissions:
 
 jobs:
   dependabot:
+    needs: [build, redirects-tests, pa11y-scan, validate_html, check_links, lint] # ensures the other checks pass before running this job
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adds list of other actions that need to pass before checking for Dependabot patches to auto-merge.

## security considerations

This should increase assurance that Dependabot patch PR's are auto-merged only after all other checks pass.
