### PR TITLE
Address TODOs in Engineering Guide

### DIFF
--- a/content/engineering/our-approach/architecture-reviews.md
+++ b/content/engineering/our-approach/architecture-reviews.md
@@ -21,9 +21,6 @@ subnav:
     href: "#documenting-key-decisions"
 
 ---
-{% comment %}
-  TODO: Need to revisit the DATA Act and micropurchase project links in the sidenav
-{% endcomment %}
 
 Maintainable technology projects require handoffs between developers, and with new teammates comes fresh perspectives. Building a [transparent and remote-friendly workplace](https://18f.gsa.gov/2015/10/15/best-practices-for-distributed-teams/) is a great start to assist in knowledge transfer, as well as keeping projects as simple and obvious as possible and documenting key decisions.
 

--- a/content/engineering/tools/accessibility-scanning.md
+++ b/content/engineering/tools/accessibility-scanning.md
@@ -38,7 +38,6 @@ While Pa11y gives you the option of different test runners, we recommend using a
 
 #### Running pa11y in CI
 - [GitHub Actions](#github-actions-on-every-pull-request)
-  - [Jekyll Specific Setup](#jekyll-specific-setup)
   - [Eleventy Specific Setup](#eleventy-specific-setup)
 - [Circle CI](#circle-ci-setup-instructions)
 
@@ -84,45 +83,6 @@ jobs:
 ```
 
 Depending on the type of technology you have built your site in, the rest of this file will vary.
-
-###### Jekyll-specific setup
-
-Add pa11y-specific scripts to `package.json`:
-
-``` json
-    "scripts": {
-      "start-detached":
-        "bundle exec jekyll serve --detach",
-      "pa11y-ci:sitemap":
-        "pa11y-ci --sitemap http://localhost:4000/sitemap.xml --sitemap-exclude \"/*.pdf\""
-    }
-```
-
-Add the following lines to your `accessibility-scan.yml` file at the end of the steps key:
-
-```yaml
-  # steps:
-    - name: Install jekyll site dependencies
-        uses: ruby/setup-ruby@v1
-        with:
-          # your preferred version here
-          ruby-version: 2.7.2
-          bundler-cache: true
-
-      - name: Install JS dependencies including pa11y-ci
-        run: npm install
-
-      - name: Start up jekyll server
-        run: npm run start-detached
-
-      - name: Run pa11y-ci
-        run: npm run pa11y-ci:sitemap
-```
-
-This installs Ruby and JavaScript dependencies, then starts Jekyll with the `start-detached` script you added to `package.json` in an earlier step. Once Jekyll has started and detached, pa11y-ci will scan URLs from the sitemap.
-
-To see a pa11y.yml live in the wild, check out [18F Accessibility site's pa11y.yml](https://github.com/18F/accessibility/blob/18f-pages/.github/workflows/pa11y.yml/TODO/).
-
 
 ###### Eleventy-specific setup
 

--- a/content/engineering/tools/accessibility-scanning.md
+++ b/content/engineering/tools/accessibility-scanning.md
@@ -84,6 +84,42 @@ jobs:
 
 Depending on the type of technology you have built your site in, the rest of this file will vary.
 
+###### Jekyll-specific setup
+
+Add pa11y-specific scripts to `package.json`:
+
+``` json
+    "scripts": {
+      "start-detached":
+        "bundle exec jekyll serve --detach",
+      "pa11y-ci:sitemap":
+        "pa11y-ci --sitemap http://localhost:4000/sitemap.xml --sitemap-exclude \"/*.pdf\""
+    }
+```
+
+Add the following lines to your `accessibility-scan.yml` file at the end of the steps key:
+
+```yaml
+  # steps:
+    - name: Install jekyll site dependencies
+        uses: ruby/setup-ruby@v1
+        with:
+          # your preferred version here
+          ruby-version: 2.7.2
+          bundler-cache: true
+
+      - name: Install JS dependencies including pa11y-ci
+        run: npm install
+
+      - name: Start up jekyll server
+        run: npm run start-detached
+
+      - name: Run pa11y-ci
+        run: npm run pa11y-ci:sitemap
+```
+
+This installs Ruby and JavaScript dependencies, then starts Jekyll with the `start-detached` script you added to `package.json` in an earlier step. Once Jekyll has started and detached, pa11y-ci will scan URLs from the sitemap.
+
 ###### Eleventy-specific setup
 
 Install `start-server-and-test`:

--- a/content/engineering/tools/accessibility-scanning.md
+++ b/content/engineering/tools/accessibility-scanning.md
@@ -57,17 +57,7 @@ Install pa11y locally:
 
 Create a `.pa11yci` in the root of your directory to [configure your pa11y CI run](https://github.com/pa11y/pa11y-ci#configuration). This step is optional, but helpful if you want to change any default configuration.
 
-For an example, take a look at the [18F accessibility site's .pallyci file](https://github.com/18F/accessibility/blob/18f-pages/.pa11yci/TODO/):
-
-```json
-    {
-      "defaults": {
-        "concurrency": 4,
-        "standard": "WCAG2AA",
-        "runners": ["axe"]
-      }
-    }
-```
+For an example, take a look at the [18F guides site's .pallyci file](https://github.com/18F/guides/blob/main/.pa11yci).
 
 Create a `.github/workflows` directory in the root of your project, and then add a file `accessibility-scan.yml` (or whatever you want to call it).
 

--- a/content/engineering/tools/accessibility-scanning.md
+++ b/content/engineering/tools/accessibility-scanning.md
@@ -38,8 +38,8 @@ While Pa11y gives you the option of different test runners, we recommend using a
 
 #### Running pa11y in CI
 - [GitHub Actions](#github-actions-on-every-pull-request)
-  - [Eleventy Specific Setup](#eleventy-specific-setup)
   - [Jekyll Specific Setup](#jekyll-specific-setup)
+  - [Eleventy Specific Setup](#eleventy-specific-setup)
 - [Circle CI](#circle-ci-setup-instructions)
 
 ##### GitHub Actions on every pull request

--- a/content/engineering/tools/accessibility-scanning.md
+++ b/content/engineering/tools/accessibility-scanning.md
@@ -39,6 +39,7 @@ While Pa11y gives you the option of different test runners, we recommend using a
 #### Running pa11y in CI
 - [GitHub Actions](#github-actions-on-every-pull-request)
   - [Eleventy Specific Setup](#eleventy-specific-setup)
+  - [Jekyll Specific Setup](#jekyll-specific-setup)
 - [Circle CI](#circle-ci-setup-instructions)
 
 ##### GitHub Actions on every pull request


### PR DESCRIPTION
## Changes proposed in this pull request:

+ Update link to `.pa11yci` example file to point to the unified guides `.pa11yci` instead of the to-be-deprecated Accessibility Guide `.pa11yci`.
+ Remove Jekyll example of setting up pa11y since (1) it points to Accessibility Guide as an example, which we are deprecating, and (2) 18F moved away from Jekyll for G&M on the assumption that it was end-of-life software.

## Issue

+ #157 
