### PR TITLE
Remove TODOs from many links to methods.18f.gov

### DIFF
--- a/content/ux-guide/research/clarify-the-basics.md
+++ b/content/ux-guide/research/clarify-the-basics.md
@@ -62,19 +62,19 @@ Background research helps you ask: what do we already know?
 
 ### Foundational research
 
-Foundational research is the research you do to identify and clarify the team’s objectives, assumptions, and constraints. On the 18F Methods site, [discover methods](https://methods.18f.gov/discover/TODO/) help to build context for the problem you’re investigating. This includes; [stakeholder and user interviews](https://methods.18f.gov/discover/stakeholder-and-user-interviews/TODO/), [heuristic evaluation](https://methods.18f.gov/discover/heuristic-evaluation/TODO/), and [hopes and fears workshops](https://methods.18f.gov/discover/hopes-and-fears/TODO/). Foundational research is primarily (though not exclusively) the domain of [18F Path Analysis](https://18f.gsa.gov/how-we-work/#path-analysis) engagements and results in, among other things, a [problem statement as outlined on our GitHub repository](https://github.com/18F/path-analysis/blob/master/approach.md#2-draft-a-problem-statement).
+Foundational research is the research you do to identify and clarify the team’s objectives, assumptions, and constraints. On the 18F Methods site, [discover methods](https://methods.18f.gov/discover/) help to build context for the problem you’re investigating. This includes; [stakeholder and user interviews](https://methods.18f.gov/discover/stakeholder-and-user-interviews/), [heuristic evaluation](https://methods.18f.gov/discover/heuristic-evaluation/), and [hopes and fears workshops](https://methods.18f.gov/discover/hopes-and-fears/). Foundational research is primarily (though not exclusively) the domain of [18F Path Analysis](https://18f.gsa.gov/how-we-work/#path-analysis) engagements and results in, among other things, a [problem statement as outlined on our GitHub repository](https://github.com/18F/path-analysis/blob/master/approach.md#2-draft-a-problem-statement).
 
 Foundational research helps you ask: what problem are we trying to solve?
 
 ### Descriptive research
 
-Descriptive research focuses on understanding, validating, and documenting the context of an assumed problem. On the 18F Methods site, [decide methods](https://methods.18f.gov/#decide/TODO/) help develop a deeper understanding of workflows and processes. It could look like describing the needs and characteristics of a particular audience like [journey mapping or Mental modeling](https://methods.18f.gov/decide/journey-mapping/TODO/).
+Descriptive research focuses on understanding, validating, and documenting the context of an assumed problem. On the 18F Methods site, [decide methods](https://methods.18f.gov/#decide) help develop a deeper understanding of workflows and processes. It could look like describing the needs and characteristics of a particular audience like [journey mapping or Mental modeling](https://methods.18f.gov/decide/journey-mapping/).
 
 Descriptive research helps you ask: who or what are we solving this problem for? 
 
 ### Generative research
 
-Generative research helps you better frame the problem(s) you’re solving, spark new ideas, and reveal opportunities. On the 18F Methods site, [make methods](https://methods.18f.gov/#make/TODO/) help create testable designs like [prototyping and Wireframing](https://methods.18f.gov/make/wireframing/TODO/) to ensure your product reflects your users’ needs. 
+Generative research helps you better frame the problem(s) you’re solving, spark new ideas, and reveal opportunities. On the 18F Methods site, [make methods](https://methods.18f.gov/#make) help create testable designs like [prototyping and Wireframing](https://methods.18f.gov/make/wireframing/) to ensure your product reflects your users’ needs. 
 
 Generative research helps you better frame the problem(s) you’re solving, spark new ideas, and reveal opportunities. 
 
@@ -88,7 +88,7 @@ Generative research helps you ask:
 
 ### Evaluative research
 
-Evaluative research is the research you do to test assumptions, hypotheses, and the ease of use of design solutions. On the 18F Methods site, [validate methods](https://methods.18f.gov/#validate/TODO/) like [multivariate testing](https://methods.18f.gov/validate/multivariate-testing/TODO/), and [usability testing ](https://methods.18f.gov/validate/usability-testing/TODO/) help to understand how to determine if the product or service delivers as you designed.
+Evaluative research is the research you do to test assumptions, hypotheses, and the ease of use of design solutions. On the 18F Methods site, [validate methods](https://methods.18f.gov/#validate) like [multivariate testing](https://methods.18f.gov/validate/multivariate-testing/), and [usability testing ](https://methods.18f.gov/validate/usability-testing/) help to understand how to determine if the product or service delivers as you designed.
 
 Evaluative research helps you ask: 
 
@@ -116,7 +116,7 @@ As a distributed team, 18F defaults to remote-friendly ways of working. This giv
 
 ### In person
 
-With most projects you’ll conduct an in-person kickoff, during which you may have the chance to meet, interview, and conduct activities with stakeholders. If feasible, consider adding [contextual inquiry as described in the 18F methods]( https://methods.18f.gov/discover/contextual-inquiry/TODO/) into your kick-off activities. Direct observation will provide firsthand understanding of your stakeholders’ and users’ processes and contexts.
+With most projects you’ll conduct an in-person kickoff, during which you may have the chance to meet, interview, and conduct activities with stakeholders. If feasible, consider adding [contextual inquiry as described in the 18F methods](https://methods.18f.gov/discover/contextual-inquiry/) into your kick-off activities. Direct observation will provide firsthand understanding of your stakeholders’ and users’ processes and contexts.
 
 We prefer in-person research when we want to better understand the environment in which users normally interact with a government service. We also prefer in-person research when our participants aren’t especially proficient with, or don’t have access to, video conferencing software.
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- Per ticket #157 
- Remove `TODO\` from a number of hyperlinks
- Per "Restore URL" instructions in [this spreadsheet](https://docs.google.com/spreadsheets/d/10Sxuh78iZqJ8feBzehGpKKYBrTDOgXxjmjggq8FG-Pg/)
- Please check my understanding that this is the correct restoration!

## security considerations

None: restoring existing functionality 
