### PR TITLE
Remove redirect for brand guide

### DIFF
--- a/_data/redirect_bases.yaml
+++ b/_data/redirect_bases.yaml
@@ -1,5 +1,4 @@
 accessibility: https://accessibility.18f.gov/
-brand: https://brand.18f.gov/
 content-guide: https://content-guide.18f.gov/
 derisking: https://derisking-guide.18f.gov/
 eng-hiring: https://eng-hiring.18f.gov/


### PR DESCRIPTION
## Changes proposed in this pull request:

- Removes client-side redirection for brand guide pages

**Why?**
Now that the brand guide is fully prepared for release, this performs [step 2 of the migration](https://docs.google.com/document/d/19b1Y2pSyw1EjXzc2XmL-qXqQCfqiVQLkypOO8zJKUKw/edit)

**Results**
This will"soft" launch the guide by making the new guide available on the web and indexable by web crawlers

**Considerations**
Brand guide content will now be available in two places on the web: on the old guide domain and on the new guide domain. This isn't great for SEO, so we want to perform steps 3, 4, and 5 shortly after accepting this change.

## security considerations

- content is now available on the web
- content is now indexable by web crawlers
