### PR TITLE
Fix: add trailing slash to permalink

### DIFF
--- a/_data/navigation.yaml
+++ b/_data/navigation.yaml
@@ -3,7 +3,7 @@ accessibility:
   - name: Home
     url: /accessibility/
   - name: Other .Gov Accessibility Sites
-    url: /accessibility/gov-resources
+    url: /accessibility/gov-resources/
 
 agile:
   - name: Home

--- a/content/accessibility/gov-resources.md
+++ b/content/accessibility/gov-resources.md
@@ -1,6 +1,6 @@
 ---
 title: Government Accessibility Resources
-permalink: /accessibility/gov-resources
+permalink: /accessibility/gov-resources/
 layout: layouts/page
 tags: accessibility
 ---


### PR DESCRIPTION
## Changes proposed in this pull request:

- Fixes 404 for `/accessibility/gov-resources` in production by adding a trailing slash to the markdown permalink

Closes #203 

## security considerations

None
