### PR TITLE
Remove client-side redirects for content, de-risking, ux guides

### DIFF
--- a/_data/redirect_bases.yaml
+++ b/_data/redirect_bases.yaml
@@ -1,7 +1,4 @@
 accessibility: https://accessibility.18f.gov/
-content-guide: https://content-guide.18f.gov/
-derisking: https://derisking-guide.18f.gov/
 eng-hiring: https://eng-hiring.18f.gov/
 engineering: https://engineering.18f.gov/
 product: https://product-guide.18f.gov/
-ux-guide: https://ux-guide.18f.gov/


### PR DESCRIPTION
:warning: will be ready for merge Monday, Dec 4

## Changes in this pull request

Remove client-side redirects for content, de-risking, ux guides

**Why?**
Now that these guides are fully prepared for release, this performs step 2 of the migration

**Results**
This will "soft" launch the guides by making the new guides available on the web and indexable by web crawlers.

**Considerations**
Content for these guides will now be available in two places on the web: on the old guide domain and on the new guide domain. This isn't great for SEO, so we want to perform steps 3, 4, and 5 shortly after accepting this change.

## security considerations

- content is now available on the web
- content is now indexable by web crawlers
