### PR TITLE
Activate brand guide codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,7 +24,7 @@
 
 # /content/accessibility/**/*.md   @jasnakai
 # /content/agile/**/*.md           @adunkman
-# /content/brand/**/*.md           @igorkorenfeld
+/content/brand/**/*.md           @igorkorenfeld
 # /content/content-guide/**/*.md   @michelle-rago
 # /content/derisking/**/*.md       @adunkman
 # /content/design/**/*.md          @MelissaBraxton


### PR DESCRIPTION
## Changes proposed in this pull request:
- Activates brand guide codeowner

Tagging @igorkorenfeld as the codeowner of the brand guide. 

## security considerations

None
