### PR TITLE
Add navigation scaffold for methods

### DIFF
--- a/_data/navigation.yaml
+++ b/_data/navigation.yaml
@@ -110,3 +110,36 @@ ux-guide:
 secondary_navigation:
   - name: More 18F guides
     url: /
+
+methods:
+  - name: Discover
+    url: /discover/
+    children:
+      - name: Cognitive walkthrough
+        url: /methods/discover/cognitive-walkthrough/
+      - name: Contextual inquiry
+        url: /methods/discover/contextual-inquiry/
+  - name: Decide
+    url: /methods/decide/
+    children:
+      - name: Affinity mapping
+        url: /methods/decide/affinity-mapping/
+  - name: Make
+    url: /methods/make/
+    children:
+      - name: Design pattern library
+        url: /methods/make/design-pattern-library/
+  - name: Validate
+    url: /methods/validate/
+    children:
+      - name: Card sorting
+        url: /methods/validate/card-sorting/
+  - name: Fundamentals
+    url: /methods/fundamentals/
+    children:
+      - name: Compensation
+        url: /methods/fundamentals/compensation/
+  - name: About
+    url: /methods/about/
+  - name: Print the Methods
+    url: /methods/print/

--- a/content/methods/about.md
+++ b/content/methods/about.md
@@ -1,0 +1,6 @@
+---
+title: About - Methods
+permalink: /methods/about/
+layout: layouts/page
+tags: methods
+---

--- a/content/methods/decide/affinity-mapping.md
+++ b/content/methods/decide/affinity-mapping.md
@@ -1,0 +1,10 @@
+---
+title: Affinity mapping
+permalink: /methods/decide/affinity-mapping/
+layout: layouts/page
+tags: methods
+eleventyNavigation:
+  key: methods
+  parent: Decide
+  title: Affinity mapping
+---

--- a/content/methods/discover/cognitive-walkthrough.md
+++ b/content/methods/discover/cognitive-walkthrough.md
@@ -1,0 +1,10 @@
+---
+title: Cognitive Walkthrough
+permalink: /methods/discover/cognitive-walkthrough/
+layout: layouts/page
+tags: methods
+eleventyNavigation:
+  key: methods
+  parent: Discover
+  title: Cognitive walkthrough
+---

--- a/content/methods/discover/contextual-inquiry.md
+++ b/content/methods/discover/contextual-inquiry.md
@@ -1,0 +1,10 @@
+---
+title: Contextual Inquiry
+permalink: /methods/discover/contextual-inquiry/
+layout: layouts/page
+tags: methods
+eleventyNavigation:
+  key: methods
+  parent: Discover
+  title: Contextual Inquiry
+---

--- a/content/methods/fundamentals/compensation.md
+++ b/content/methods/fundamentals/compensation.md
@@ -1,0 +1,12 @@
+---
+title: Compensation
+permalink: /methods/fundamentals/compensation/
+layout: layouts/page
+tags: methods
+eleventyNavigation:
+  key: methods
+  parent: Fundamentals
+  title: Compensation
+---
+
+

--- a/content/methods/make/design-pattern-library.md
+++ b/content/methods/make/design-pattern-library.md
@@ -1,0 +1,12 @@
+---
+title: Design pattern library
+permalink: /methods/make/design-pattern-library/
+layout: layouts/page
+tags: methods
+eleventyNavigation:
+  key: methods
+  parent: Make
+  title: Design pattern library
+---
+
+

--- a/content/methods/print.md
+++ b/content/methods/print.md
@@ -1,0 +1,6 @@
+---
+title: Print - Methods
+permalink: /methods/print/
+layout: layouts/page
+tags: methods
+---

--- a/content/methods/validate/card-sorting.md
+++ b/content/methods/validate/card-sorting.md
@@ -1,0 +1,12 @@
+---
+title: Card sorting
+permalink: /methods/validate/card-sorting/
+layout: layouts/page
+tags: methods
+eleventyNavigation:
+  key: methods
+  parent: Validate
+  title: Card sorting
+---
+
+


### PR DESCRIPTION
## Changes proposed in this pull request:

Closes #226

- Adds navigation scaffold to get a sense of what it would look like
- integrating methods links into new site means changing position of "About" and "Print" links (see screenshots)
- Adds corresponding placeholder pages to make link tests pass

New site screens:

Closed:
![Screenshot 2023-12-05 at 1 22 59 PM](https://github.com/18F/guides/assets/4267629/f7605bf9-4145-49ea-8d76-3c896fcb6c2c)

Open:
![Screenshot 2023-12-05 at 1 23 07 PM](https://github.com/18F/guides/assets/4267629/615b55fb-07b3-4b50-b4ee-45e5348d1fd5)


Mobile:
![Screenshot 2023-12-05 at 1 27 19 PM](https://github.com/18F/guides/assets/4267629/7d7e8dd3-2096-4daa-9acd-b83e944d6eb4)



## security considerations

None since this is adding frontend content to a dev environment
