### PR TITLE
Remove client-side redirect and noindex meta tag for guides batch 2

### DIFF
--- a/_data/redirect_bases.yaml
+++ b/_data/redirect_bases.yaml
@@ -1,1 +1,2 @@
+engineering: https://engineering.18f.gov/
 methods: https://methods.18f.gov/

--- a/_data/redirect_bases.yaml
+++ b/_data/redirect_bases.yaml
@@ -1,5 +1,1 @@
-accessibility: https://accessibility.18f.gov/
-eng-hiring: https://eng-hiring.18f.gov/
-engineering: https://engineering.18f.gov/
-product: https://product-guide.18f.gov/
 methods: https://methods.18f.gov/


### PR DESCRIPTION
## Changes proposed in this pull request:

- Removes client-side redirect and noindex meta tags for accessibility, eng-hiring, and product guides
- This makes new guides urls available online and reachable by search engines (including search.gov)

This is step #2 ("soft launch") in the [migration guide](https://docs.google.com/document/d/19b1Y2pSyw1EjXzc2XmL-qXqQCfqiVQLkypOO8zJKUKw/edit#heading=h.quhbb0wqtaay)

## security considerations

None
