### PR TITLE
Activate codeowners for content, derisking, ux guides

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,13 +25,13 @@
 # /content/accessibility/**/*.md   @jasnakai
 # /content/agile/**/*.md           @adunkman
 /content/brand/**/*.md           @igorkorenfeld
-# /content/content-guide/**/*.md   @michelle-rago
-# /content/derisking/**/*.md       @adunkman
+/content/content-guide/**/*.md   @michelle-rago
+/content/derisking/**/*.md       @adunkman
 # /content/design/**/*.md          @MelissaBraxton
 # /content/eng-hiring/**/*.md      @amymok
 # /content/engineering/**/*.md     @amymok
 # /content/product/**/*.md         @allisonnorman
-# /content/ux-guide/**/*.md        @juliaklindpaintner
+/content/ux-guide/**/*.md        @juliaklindpaintner
 
 # The pull request template and CODEOWNERS files should be reviewed by the Chief of Delivery;
 # placed at the end of the file to ensure they are not overridden by another rule.


### PR DESCRIPTION
## Changes proposed in this pull request:

- Activate github codeowners for these guides, so that they'll be notified of pull requests for their guide

## security considerations

None as this is not a functional change
