### PR TITLE
incomplete implementation of possible client-side redirect behavior

### DIFF
--- a/content/content-guide/our-approach/structure-the-content.md
+++ b/content/content-guide/our-approach/structure-the-content.md
@@ -4,9 +4,6 @@ permalink: /content-guide/our-approach/structure-the-content/
 layout: layouts/page
 sidenav: true
 sticky_sidenav: true
-redirect_from:
-  - /faqs
-  - /how-users-read/
 subnav:
   - text: Important information first
     href: '#important-information-first'

--- a/content/content-guide/our-style/abbreviations-and-acronyms.md
+++ b/content/content-guide/our-style/abbreviations-and-acronyms.md
@@ -5,8 +5,9 @@ layout: layouts/page
 sidenav: true
 sticky_sidenav: true
 redirect_from:
-  - /faqs
-  - /how-users-read/
+  - content-guide/faqs
+  - content-guide/how-users-read/
+  - content-guide/abbreviations-and-acronyms/
 tags: content-guide
 eleventyNavigation:
   key: content-abbrivs

--- a/content/redirect.html
+++ b/content/redirect.html
@@ -1,0 +1,47 @@
+---js
+{
+  pagination: {
+    data: "collections.all",
+    size: 1,
+    alias: "redirect",
+    before: function (data) {
+      const all = data.reduce((redirects, page) => {
+        if (Array.isArray(page.data.redirect_from)) {
+          for (let url of page.data.redirect_from) {
+            redirects.push({ to: page.url, from: url });
+          }
+        } else if (typeof page.data.redirect_from === 'string') {
+          redirects.push({ to: page.url, from: page.data.redirect_from });
+        }
+        if (page.data.redirect_from) {
+        }
+        return (redirects);
+      }, []);
+
+      return all.filter(({ to, from })=> to !== from);
+    },
+    addAllPagesToCollections: false,
+  },
+  permalink: "{{ redirect.from }}/index.html",
+  eleventyExcludeFromCollections: true,
+}
+---
+
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <meta charset="utf-8" />
+    <title>Redirecting&hellip;</title>
+    <link rel="canonical" href="{{ redirect.to | url }}" />
+    <script>
+      location = "{{ redirect.to | url }}"
+    </script>
+    <meta name="rel-path" content="{{ redirect.to | url }}" />
+    <meta http-equiv="refresh" content="0; url={{ redirect.to | url }}" />
+    <meta name="robots" content="noindex" />
+  </head>
+  <body>
+    <h1>Redirecting&hellip;</h1>
+    <a href="{{ redirect.to | url }}">Click here if you are not redirected.</a>
+  </body>
+</html>


### PR DESCRIPTION
## Changes proposed in this pull request:

Implements version of redirect behavior from [TTS handbook](https://github.com/18F/handbook/blob/main/pages/redirect.html)

There were already `redirect_from` properties in the frontmatter of many pages, which I have not altered. I only changed two files for testing:

1. `structure-the-content` because it had duplicate redirects that were causing 11ty to error
2. `abbreviations-and-acronyms` to test a couple redirects for the content-guide

I have concerns about the absolute vs relative URL paths, so we are going to test on production to see if this is working.