### PR TITLE
Fix engineering guide redirects

### DIFF
--- a/content/engineering/about/license.md
+++ b/content/engineering/about/license.md
@@ -1,6 +1,8 @@
 ---
 title: License
 permalink: /engineering/about/license/
+redirect_from:
+  - engineering/license/
 layout: layouts/page
 sidenav: true
 sticky_sidenav: true

--- a/content/engineering/about/resources.md
+++ b/content/engineering/about/resources.md
@@ -1,6 +1,8 @@
 ---
 title: Resources
 permalink: /engineering/about/resources/
+redirect_from:
+  - engineering/resources/
 layout: layouts/page
 sidenav: true
 sticky_sidenav: true

--- a/content/engineering/languages-runtimes/css.md
+++ b/content/engineering/languages-runtimes/css.md
@@ -11,17 +11,18 @@ eleventyNavigation:
   order: 6
   title: CSS
 redirect_from:
-  - /css/architecture/
-  - /css/documentation/
-  - /css/frameworks/
-  - /css/formatting/
-  - /css/inheritance/
-  - /css/linting/
-  - /css/naming/
-  - /css/preprocessors/
-  - /css/specificity/
-  - /css/units/
-  - /css/variables/
+  - engineering/css/
+  - engineering/css/architecture/
+  - engineering/css/documentation/
+  - engineering/css/frameworks/
+  - engineering/css/formatting/
+  - engineering/css/inheritance/
+  - engineering/css/linting/
+  - engineering/css/naming/
+  - engineering/css/preprocessors/
+  - engineering/css/specificity/
+  - engineering/css/units/
+  - engineering/css/variables/
 subnav:
   - text: Architecture
     href: "#architecture"

--- a/content/engineering/languages-runtimes/javascript.md
+++ b/content/engineering/languages-runtimes/javascript.md
@@ -11,9 +11,10 @@ eleventyNavigation:
   order: 2
   title: JavaScript
 redirect_from:
-  - /javascript/dependencies/
-  - /javascript/frameworks/
-  - /javascript/style/
+  - engineering/javascript/
+  - engineering/javascript/dependencies/
+  - engineering/javascript/frameworks/
+  - engineering/javascript/style/
 subnav:
   - text: Dependencies
     href: "#dependencies"

--- a/content/engineering/languages-runtimes/language-selection.md
+++ b/content/engineering/languages-runtimes/language-selection.md
@@ -3,6 +3,8 @@ title: Languages & runtimes
 sidenav: true
 sticky_sidenav: true
 permalink: /engineering/languages-runtimes/
+redirect_from:
+  - engineering/language-selection/
 tags: engineering
 layout: layouts/page
 eleventyNavigation:

--- a/content/engineering/languages-runtimes/markdown.md
+++ b/content/engineering/languages-runtimes/markdown.md
@@ -3,6 +3,8 @@ title: Markdown guide
 sidenav: true
 sticky_sidenav: true
 permalink: /engineering/languages-runtimes/markdown/
+redirect_from:
+  - engineering/markdown/
 tags: engineering
 layout: layouts/page
 eleventyNavigation: 

--- a/content/engineering/languages-runtimes/nodejs.md
+++ b/content/engineering/languages-runtimes/nodejs.md
@@ -3,6 +3,8 @@ title: Node.js
 sidenav: true
 sticky_sidenav: true
 permalink: /engineering/languages-runtimes/nodejs/
+redirect_from:
+  - engineering/nodejs/
 tags: engineering
 layout: layouts/page
 eleventyNavigation:

--- a/content/engineering/languages-runtimes/python.md
+++ b/content/engineering/languages-runtimes/python.md
@@ -3,6 +3,8 @@ title: Python development guide
 sidenav: true
 sticky_sidenav: true
 permalink: /engineering/languages-runtimes/python/
+redirect_from:
+  - engineering/python/
 tags: engineering
 layout: layouts/page
 eleventyNavigation: 

--- a/content/engineering/languages-runtimes/ruby.md
+++ b/content/engineering/languages-runtimes/ruby.md
@@ -3,6 +3,8 @@ title: Ruby guide
 sidenav: true
 sticky_sidenav: true
 permalink: /engineering/languages-runtimes/ruby/
+redirect_from:
+  - engineering/ruby/
 tags: engineering
 layout: layouts/page
 eleventyNavigation:

--- a/content/engineering/our-approach/apis.md
+++ b/content/engineering/our-approach/apis.md
@@ -4,6 +4,8 @@ sidenav: true
 sticky_sidenav: true
 tags: engineering
 permalink: /engineering/our-approach/apis/
+redirect_from:
+  - engineering/apis/
 layout: layouts/page
 eleventyNavigation: 
   parent: engineering_approach

--- a/content/engineering/our-approach/architecture-reviews.md
+++ b/content/engineering/our-approach/architecture-reviews.md
@@ -3,6 +3,10 @@ title: Architecture reviews
 sidenav: true
 sticky_sidenav: true
 permalink: /engineering/our-approach/architecture-reviews/
+redirect_from:
+  - engineering/architecture-reviews/
+  - engineering/architecture-reviews/data-act-pilot/
+  - engineering/architecture-reviews/micro-purchase/
 tags: engineering
 layout: layouts/page
 eleventyNavigation:

--- a/content/engineering/our-approach/code-review.md
+++ b/content/engineering/our-approach/code-review.md
@@ -1,6 +1,8 @@
 ---
 title: Code review
 permalink: /engineering/our-approach/code-review/
+redirect_from:
+  - engineering/code-review/
 sidenav: true
 sticky_sidenav: true
 tags: engineering

--- a/content/engineering/our-approach/development-environments.md
+++ b/content/engineering/our-approach/development-environments.md
@@ -1,6 +1,8 @@
 ---
 title: Development environments
-permalink: /engineering/our-approach/development-enivorments/
+permalink: /engineering/our-approach/development-environments/
+redirect_from:
+  - engineering/development-environments/
 sidenav: true
 sticky_sidenav: true
 tags: engineering

--- a/content/engineering/our-approach/example-workflows.md
+++ b/content/engineering/our-approach/example-workflows.md
@@ -3,6 +3,8 @@ title: Example workflows
 sidenav: true
 sticky_sidenav: true
 permalink: /engineering/our-approach/example-workflows/
+redirect_from:
+  - engineering/example-workflows/
 tags: engineering
 layout: layouts/page
 eleventyNavigation: 

--- a/content/engineering/our-approach/frontend.md
+++ b/content/engineering/our-approach/frontend.md
@@ -4,6 +4,8 @@ sidenav: true
 sticky_sidenav: true
 tags: engineering
 permalink: /engineering/our-approach/frontend/
+redirect_from:
+  - engineering/frontend/
 layout: layouts/page
 eleventyNavigation:
   parent: engineering_approach

--- a/content/engineering/our-approach/incident-reports.md
+++ b/content/engineering/our-approach/incident-reports.md
@@ -11,7 +11,8 @@ eleventyNavigation:
   order: 5
   title: Incident reports
 redirect_from:
-  /incident-reports/cloud-gov/
+  - engineering/incident-reports/
+  - engineering/incident-reports/cloud-gov/
 subnav:
   - text: Key components
     href: "#key-components"

--- a/content/engineering/our-approach/on-call.md
+++ b/content/engineering/our-approach/on-call.md
@@ -3,6 +3,8 @@ title: On-call recommendations
 sidenav: true
 sticky_sidenav: true
 permalink: /engineering/our-approach/on-call/
+redirect_from:
+  - engineering/on-call/
 tags: engineering
 layout: layouts/page
 eleventyNavigation: 

--- a/content/engineering/our-approach/people.md
+++ b/content/engineering/our-approach/people.md
@@ -1,6 +1,8 @@
 ---
 title: Feedback guide
 permalink: /engineering/our-approach/people/
+redirect_from:
+  - engineering/people/
 layout: layouts/page
 sidenav: true
 sticky_sidenav: true

--- a/content/engineering/our-approach/people/assessment.md
+++ b/content/engineering/our-approach/people/assessment.md
@@ -3,6 +3,8 @@ title: 18F Engineering end of year assessment guide
 sidenav: true
 sticky_sidenav: true
 permalink: /engineering/our-approach/people/assessment/
+redirect_from:
+  - engineering/people/assessment/
 tags: engineering
 layout: layouts/page
 eleventyNavigation: 

--- a/content/engineering/our-approach/release-strategies.md
+++ b/content/engineering/our-approach/release-strategies.md
@@ -4,6 +4,8 @@ sidenav: true
 sticky_sidenav: true
 tags: engineering
 permalink: /engineering/our-approach/release-strategies/
+redirect_from:
+  - engineering/release-strategies/
 layout: layouts/page
 eleventyNavigation:
   parent: engineering_approach

--- a/content/engineering/our-approach/workflow.md
+++ b/content/engineering/our-approach/workflow.md
@@ -1,6 +1,8 @@
 ---
 title: Our approach
 permalink: /engineering/our-approach/
+redirect_from:
+  - engineering/workflow/
 layout: layouts/page
 sidenav: true
 sticky_sidenav: true

--- a/content/engineering/tools/accessibility-scanning.md
+++ b/content/engineering/tools/accessibility-scanning.md
@@ -3,6 +3,8 @@ title: Accessibility scanning
 sidenav: true
 sticky_sidenav: true
 permalink: /engineering/tools/accessibility-scanning/
+redirect_from:
+  - engineering/accessibility-scanning/
 tags: engineering
 layout: layouts/page
 eleventyNavigation:

--- a/content/engineering/tools/books-we-have-read.md
+++ b/content/engineering/tools/books-we-have-read.md
@@ -3,6 +3,8 @@ title: Books we've read
 sidenav: true
 sticky_sidenav: true
 permalink: /engineering/tools/books-we-have-read/
+redirect_from:
+  - engineering/books-we-have-read/
 tags: engineering
 layout: layouts/page
 eleventyNavigation: 

--- a/content/engineering/tools/browser-testing.md
+++ b/content/engineering/tools/browser-testing.md
@@ -3,6 +3,8 @@ title: Browser testing
 sidenav: true
 sticky_sidenav: true
 permalink: /engineering/tools/browser-testing/
+redirect_from:
+  - engineering/browser-testing/
 tags: engineering
 layout: layouts/page
 eleventyNavigation: 

--- a/content/engineering/tools/continuous-deployment.md
+++ b/content/engineering/tools/continuous-deployment.md
@@ -3,6 +3,8 @@ title: Continuous deployment
 sidenav: true
 sticky_sidenav: true
 permalink: /engineering/tools/continuous-deployment/
+redirect_from:
+  - engineering/continuous-deployment/
 tags: engineering
 layout: layouts/page
 eleventyNavigation:

--- a/content/engineering/tools/datastore-selection.md
+++ b/content/engineering/tools/datastore-selection.md
@@ -3,6 +3,8 @@ title: Datastore selection
 sidenav: true
 sticky_sidenav: true
 permalink: /engineering/tools/datastore-selection/
+redirect_from:
+  - engineering/datastore-selection/
 tags: engineering
 layout: layouts/page
 eleventyNavigation: 

--- a/content/engineering/tools/docker.md
+++ b/content/engineering/tools/docker.md
@@ -11,7 +11,8 @@ eleventyNavigation:
   order: 4
   title: Docker for development
 redirect_from:
-  - /project-setup/docker/
+  - engineering/docker/
+  - engineering/project-setup/docker/
 subnav:
   - text: Why?
     href: "#why"

--- a/content/engineering/tools/integrations.md
+++ b/content/engineering/tools/integrations.md
@@ -3,6 +3,8 @@ title: Tools
 sidenav: true
 sticky_sidenav: true
 permalink: /engineering/tools/
+redirect_from:
+  - engineering/integrations/
 tags: engineering
 layout: layouts/page
 eleventyNavigation: 

--- a/content/engineering/tools/laptop-setup.md
+++ b/content/engineering/tools/laptop-setup.md
@@ -3,6 +3,8 @@ title: Laptop setup
 sidenav: true
 sticky_sidenav: true
 permalink: /engineering/tools/laptop-setup/
+redirect_from:
+  - engineering/laptop-setup/
 tags: engineering
 layout: layouts/page
 eleventyNavigation: 

--- a/content/engineering/tools/project-setup.md
+++ b/content/engineering/tools/project-setup.md
@@ -3,6 +3,8 @@ title: Project setup
 sidenav: true
 sticky_sidenav: true
 permalink: /engineering/tools/project-setup/
+redirect_from:
+  - engineering/project-setup/
 tags: engineering
 layout: layouts/page
 eleventyNavigation:

--- a/content/engineering/tools/sharepoint.md
+++ b/content/engineering/tools/sharepoint.md
@@ -3,6 +3,8 @@ title: A modern SharePoint primer
 sidenav: true
 sticky_sidenav: true
 permalink: /engineering/tools/sharepoint/
+redirect_from:
+  - engineering/sharepoint/
 tags: engineering
 layout: layouts/page
 eleventyNavigation: 

--- a/content/engineering/tools/tests.md
+++ b/content/engineering/tools/tests.md
@@ -3,6 +3,8 @@ title: Automated testing
 sidenav: true
 sticky_sidenav: true
 permalink: /engineering/tools/tests/
+redirect_from:
+  - engineering/tests/
 tags: engineering
 layout: layouts/page
 eleventyNavigation: 

--- a/content/engineering/tools/web-architecture.md
+++ b/content/engineering/tools/web-architecture.md
@@ -3,6 +3,8 @@ title: Choosing a web app architecture
 sidenav: true
 sticky_sidenav: true
 permalink: /engineering/tools/web-architecture/
+redirect_from:
+  - engineering/web-architecture/
 tags: engineering
 layout: layouts/page
 eleventyNavigation:


### PR DESCRIPTION
## Changes proposed in this pull request:

- This links pages from the old engineering guide sitemap to their respective new permalinks.
- It also fixes existing `redirect_from` directives that were ported over from the old repo by prepending them with `engineering/`.

## security considerations

None
