### PR TITLE
Soft-launch engineering guide

### DIFF
--- a/_data/redirect_bases.yaml
+++ b/_data/redirect_bases.yaml
@@ -1,2 +1,1 @@
-engineering: https://engineering.18f.gov/
 methods: https://methods.18f.gov/


### PR DESCRIPTION
Now that client-side redirects are in place, we can soft-launch this guide

## Changes proposed in this pull request:

- removes temporary client-side redirects for engineering guide and noindex meta tag

This is Step #2 in [migration guide](https://docs.google.com/document/d/19b1Y2pSyw1EjXzc2XmL-qXqQCfqiVQLkypOO8zJKUKw/edit#heading=h.quhbb0wqtaay)

## security considerations

None
