### PR TITLE
Fix client-side redirects for content guide

### DIFF
--- a/content/content-guide/about-this-guide/index.md
+++ b/content/content-guide/about-this-guide/index.md
@@ -1,6 +1,8 @@
 ---
 title: About this guide
 permalink: /content-guide/
+redirect_from:
+  - content-guide/how-to-use-this-guide/
 layout: layouts/page
 sidenav: true
 sticky_sidenav: true

--- a/content/content-guide/our-approach/address-the-user.md
+++ b/content/content-guide/our-approach/address-the-user.md
@@ -1,6 +1,8 @@
 ---
 title: Address the user
 permalink: /content-guide/our-approach/address-the-user/
+redirect_from:
+  - content-guide/address-the-user/
 layout: layouts/page
 sidenav: true
 sticky_sidenav: true

--- a/content/content-guide/our-approach/avoid-duplication.md
+++ b/content/content-guide/our-approach/avoid-duplication.md
@@ -1,6 +1,8 @@
 ---
 title: Avoid duplication
 permalink: /content-guide/our-approach/avoid-duplication/
+redirect_from:
+  - content-guide/avoid-duplication/
 layout: layouts/page
 sidenav: true
 sticky_sidenav: true

--- a/content/content-guide/our-approach/be-concise.md
+++ b/content/content-guide/our-approach/be-concise.md
@@ -1,6 +1,8 @@
 ---
 title: Be concise
 permalink: /content-guide/our-approach/be-concise/
+redirect_from:
+  - content-guide/be-concise/
 layout: layouts/page
 sidenav: true
 sticky_sidenav: true

--- a/content/content-guide/our-approach/gather-feedback.md
+++ b/content/content-guide/our-approach/gather-feedback.md
@@ -1,6 +1,8 @@
 ---
 title: Gather feedback
 permalink: /content-guide/our-approach/gather-feedback/
+redirect_from:
+  - content-guide/giving-and-receiving-feedback/
 layout: layouts/page
 sidenav: true
 sticky_sidenav: true

--- a/content/content-guide/our-approach/index.md
+++ b/content/content-guide/our-approach/index.md
@@ -1,6 +1,8 @@
 ---
 title: Our approach
 permalink: /content-guide/our-approach/
+redirect_from:
+  - content-guide/our-approach/content-principles/
 layout: layouts/page
 sidenav: true
 sticky_sidenav: true

--- a/content/content-guide/our-approach/keep-refining.md
+++ b/content/content-guide/our-approach/keep-refining.md
@@ -1,6 +1,8 @@
 ---
 title: Keep refining
 permalink: /content-guide/our-approach/keep-refining/
+redirect_from:
+  - content-guide/keep-refining/
 layout: layouts/page
 sidenav: true
 sticky_sidenav: true

--- a/content/content-guide/our-approach/make-content-web-friendly.md
+++ b/content/content-guide/our-approach/make-content-web-friendly.md
@@ -1,6 +1,8 @@
 ---
 title: Make content web-friendly
 permalink: /content-guide/our-approach/make-content-web-friendly/
+redirect_from:
+  - content-guide/make-content-web-friendly/
 layout: layouts/page
 sidenav: true
 sticky_sidenav: true

--- a/content/content-guide/our-approach/plain-language.md
+++ b/content/content-guide/our-approach/plain-language.md
@@ -5,7 +5,8 @@ layout: layouts/page
 sidenav: true
 sticky_sidenav: true
 redirect_from:
-  - /legal-and-technical-terms/
+  - content-guide/plain-language/
+  - content-guide/legal-and-technical-terms/
 subnav:
   - text: Words to avoid
     href: '#words-to-avoid'

--- a/content/content-guide/our-approach/structure-the-content.md
+++ b/content/content-guide/our-approach/structure-the-content.md
@@ -1,6 +1,8 @@
 ---
 title: Structure the content
 permalink: /content-guide/our-approach/structure-the-content/
+redirect_from:
+  - content-guide/structure-the-content/
 layout: layouts/page
 sidenav: true
 sticky_sidenav: true

--- a/content/content-guide/our-style/active-voice.md
+++ b/content/content-guide/our-style/active-voice.md
@@ -1,6 +1,8 @@
 ---
 title: Active voice
 permalink: /content-guide/our-style/active-voice/
+redirect_from:
+  - content-guide/active-voice/
 layout: layouts/page
 sidenav: true
 sticky_sidenav: true

--- a/content/content-guide/our-style/capitalization.md
+++ b/content/content-guide/our-style/capitalization.md
@@ -1,6 +1,8 @@
 ---
 title: Capitalization
 permalink: /content-guide/our-style/capitalization/
+redirect_from:
+  - content-guide/capitalization/
 layout: layouts/page
 sidenav: true
 sticky_sidenav: true

--- a/content/content-guide/our-style/inclusive-language.md
+++ b/content/content-guide/our-style/inclusive-language.md
@@ -16,7 +16,8 @@ subnav:
   - text: Race, ethnicity, and religion
     href: '#race-ethnicity-and-religion'        
 redirect_from:
-  - /conscious-style/
+  - content-guide/inclusive-language/
+  - content-guide/conscious-style/
 tags: content-guide
 eleventyNavigation:
   key: content-inclusive

--- a/content/content-guide/our-style/index.md
+++ b/content/content-guide/our-style/index.md
@@ -1,6 +1,10 @@
 ---
 title: Our style 
 permalink: /content-guide/our-style/
+redirect_from:
+  - content-guide/forms/
+  - content-guide/headings-and-titles/
+  - content-guide/images/
 layout: layouts/page
 sidenav: true
 sticky_sidenav: true

--- a/content/content-guide/our-style/names.md
+++ b/content/content-guide/our-style/names.md
@@ -1,6 +1,8 @@
 ---
 title: Names
 permalink: /content-guide/our-style/names/
+redirect_from:
+  - content-guide/names/
 layout: layouts/page
 sidenav: true
 sticky_sidenav: true

--- a/content/content-guide/our-style/numbers-and-percentages.md
+++ b/content/content-guide/our-style/numbers-and-percentages.md
@@ -1,6 +1,8 @@
 ---
 title: Numbers, percentages, and dates
 permalink: /content-guide/our-style/numbers-and-percentages/
+redirect_from:
+  - content-guide/numbers-and-percentages/
 layout: layouts/page
 sidenav: true
 sticky_sidenav: true

--- a/content/content-guide/our-style/punctuation.md
+++ b/content/content-guide/our-style/punctuation.md
@@ -1,6 +1,8 @@
 ---
 title: Punctuation
 permalink: /content-guide/our-style/punctuation/
+redirect_from:
+  - content-guide/punctuation/
 layout: layouts/page
 sidenav: true
 sticky_sidenav: true

--- a/content/content-guide/our-style/specific-words-and-phrases.md
+++ b/content/content-guide/our-style/specific-words-and-phrases.md
@@ -1,6 +1,8 @@
 ---
 title: Specific words and phrases
 permalink: /content-guide/our-style/specific-words-and-phrases/
+redirect_from:
+  - content-guide/specific-words-and-phrases/
 layout: layouts/page
 sidenav: true
 sticky_sidenav: true

--- a/content/content-guide/our-style/style-guides.md
+++ b/content/content-guide/our-style/style-guides.md
@@ -1,6 +1,8 @@
 ---
 title: Style guides
 permalink: /content-guide/our-style/style-guides/
+redirect_from:
+  - content-guide/style-guides/
 layout: layouts/page
 sidenav: true
 sticky_sidenav: true

--- a/content/content-guide/our-style/technical-and-interface-writing.md
+++ b/content/content-guide/our-style/technical-and-interface-writing.md
@@ -1,6 +1,8 @@
 ---
 title: Technical and interface writing
 permalink: /content-guide/our-style/technical-and-interface-writing/
+redirect_from:
+  - content-guide/technical-and-interface-writing/
 layout: layouts/page
 sidenav: true
 sticky_sidenav: true

--- a/content/content-guide/our-style/trademarks-and-brands.md
+++ b/content/content-guide/our-style/trademarks-and-brands.md
@@ -1,6 +1,8 @@
 ---
 title: Trademarks and brands
 permalink: /content-guide/our-style/trademarks-and-brands/
+redirect_from:
+  - content-guide/trademarks-and-brands/
 layout: layouts/page
 sidenav: true
 sticky_sidenav: true

--- a/content/content-guide/our-style/urls-and-filenames.md
+++ b/content/content-guide/our-style/urls-and-filenames.md
@@ -1,6 +1,8 @@
 ---
 title: URLs and filenames
 permalink: /content-guide/our-style/urls-and-filenames/
+redirect_from:
+  - content-guide/urls-and-filenames/
 layout: layouts/page
 sidenav: true
 sticky_sidenav: true

--- a/content/content-guide/our-style/voice-and-tone.md
+++ b/content/content-guide/our-style/voice-and-tone.md
@@ -1,6 +1,8 @@
 ---
 title: Voice and tone
 permalink: /content-guide/our-style/voice-and-tone/
+redirect_from:
+  - content-guide/voice-and-tone/
 layout: layouts/page
 sidenav: true
 sticky_sidenav: true

--- a/content/derisking/qasp.md
+++ b/content/derisking/qasp.md
@@ -2,7 +2,7 @@
 title: Sample Quality Assessment Surveillance Plan (QASP)
 permalink: /derisking/qasp/
 redirect_from:
-  - /state-field-guide/qasp/
+  - derisking/state-field-guide/qasp/
 layout: layouts/page
 tags: derisking
 ---


### PR DESCRIPTION
## Changes proposed in this pull request:

- updates `redirect_from` directives to conform to urls from the old guide sitemap for content guide and 1 derisking guide url. 

## security considerations

None
