### PR TITLE
Fix one more content guide redirect

### DIFF
--- a/content/content-guide/our-approach/index.md
+++ b/content/content-guide/our-approach/index.md
@@ -2,6 +2,7 @@
 title: Our approach
 permalink: /content-guide/our-approach/
 redirect_from:
+  - content-guide/content-principles/
   - content-guide/our-approach/content-principles/
 layout: layouts/page
 sidenav: true


### PR DESCRIPTION
## Changes proposed in this pull request:

- redirects `/content-guide/content-principles` to `/content-guide/our-approach`
-
-

## security considerations

None
