### PR TITLE
Add about page to methods guide

### DIFF
--- a/content/methods/about.md
+++ b/content/methods/about.md
@@ -1,6 +1,19 @@
 ---
-title: About - Methods
+title: About
 permalink: /methods/about/
 layout: layouts/page
 tags: methods
 ---
+
+The 18F Methods are a collection of tools that describe how our teams put human-centered design into practice. We’ve gathered them here and created simplified instructions to help other organizations and federal offices adopt human-centered design into their own projects. These cards are focused on design in the context of digital services, but can be adapted to non-technical design projects as well.
+
+## The basics of human-centered design
+Human-centered design, also referred to as "user-centered design," is a methodology that incorporates feedback from the people for whom you are designing throughout the design process. The goal of human-centered design is to end up with a solution that is tailored to meet people's needs, with little wasted effort and reduced risk. To achieve this goal, design teams at 18F talk with and observe real users to understand their needs, context, and challenges, come up with design concepts that might address these challenges, and then test them with real users. Find more resources on human-centered design in government in 18F's [User Experience Design Guide](https://guides.18f.gov/ux-guide/) or at [digital.gov](https://digital.gov/topics/design/), including this overview of [the basics of human-centered design in government](https://www.youtube.com/watch?v=DGDCd2ELpok) from the Lab@OPM.
+
+## Using the 18F Methods
+The 18F Methods are broken up into the four broad design phases your team is likely to go through during a project. The four phases are [Discover]({{ "/methods/discover/" | url }}), [Decide]({{ "/methods/decide/" | url }}), [Make]({{ "/methods/make/" | url }}), [Validate]({{ "/methods//validate/" | url }}). We provide cards that walk you through the steps of each phase and cards that deal with the [fundamentals]({{ "/methods/fundamentals/" | url }}). While some cards refer to other methods, you may use them independently. You do not need to use all the cards in a section or complete certain tasks before moving on to others. Take whatever cards are most useful to your team and incorporate more tools as you’re ready.
+
+We’ve included additional guidance for using these methods in government research, specifically around the [Paperwork Reduction Act (PRA)](https://www.opm.gov/about-us/open-government/digital-government-strategy/fitara/paperwork-reduction-act-guide.pdf). We’re only able to include brief guidance on the PRA, and federal workers should check with their agency counsel for additional guidance. You should also read the cards in the fundamentals section for more background on conducting design research as a government employee.
+
+## Go behind the scenes
+As with all of 18F’s products, the 18F Methods are completely open source. You are free to copy, share, or reuse them [as you wish](https://github.com/18F/methods/blob/staging/LICENSE.md). We also welcome input from the public or our government colleagues, whether it’s correcting a typo or suggesting a new method to include. You can see our [guidelines for contributing on GitHub](https://github.com/18F/guides/blob/main/CONTRIBUTING.md). To share your feedback about the Methods site, open an issue or pull request in [our GitHub repository](https://github.com/18F/guides).

--- a/content/methods/decide/index.md
+++ b/content/methods/decide/index.md
@@ -1,0 +1,8 @@
+---
+  title: Decide
+  permalink: /methods/decide/
+  layout: layouts/method-category
+  tags: methods
+  category: decide
+  eleventyExcludeFromCollections: true
+---

--- a/content/methods/fundamentals/index.md
+++ b/content/methods/fundamentals/index.md
@@ -1,0 +1,8 @@
+---
+  title: Fundamentals
+  permalink: /methods/fundamentals/
+  layout: layouts/method-category
+  tags: methods
+  category: fundamentals
+  eleventyExcludeFromCollections: true
+---

--- a/content/methods/make/index.md
+++ b/content/methods/make/index.md
@@ -1,0 +1,8 @@
+---
+  title: Make
+  permalink: /methods/make/
+  layout: layouts/method-category
+  tags: methods
+  category: make
+  eleventyExcludeFromCollections: true
+---

--- a/content/methods/validate/index.md
+++ b/content/methods/validate/index.md
@@ -1,0 +1,8 @@
+---
+  title: Validate
+  permalink: /methods/validate/
+  layout: layouts/method-category
+  tags: methods
+  category: validate
+  eleventyExcludeFromCollections: true
+---


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adds About page to Methods guide: `/methods/about/`
- Adds placeholder pages to make link tests pass

@juliaklindpaintner @christophermather The current Methods guide has a list of [release notes](https://methods.18f.gov/about/#release-notes) at the bottom of its About page. Considering that we're changing how guides are maintained, do we want to keep the practice of publishing release notes for Methods?

Closes #232 

## security considerations

None
