### PR TITLE
Adds method guide cards from discovery category

### DIFF
--- a/_data/navigation.yaml
+++ b/_data/navigation.yaml
@@ -119,6 +119,24 @@ methods:
         url: /methods/discover/cognitive-walkthrough/
       - name: Contextual inquiry
         url: /methods/discover/contextual-inquiry/
+      - name: Design studio
+        url: /methods/discover/design-studio/
+      - name: Dot voting
+        url: /methods/discover/dot-voting/
+      - name: Five whys
+        url: /methods/discover/five-whys/
+      - name: Heuristic evaluation
+        url: /methods/discover/heuristic-evaluation/
+      - name: Hopes and fears
+        url: /methods/discover/hopes-and-fears/
+      - name: KJ method
+        url: /methods/discover/kj-method/
+      - name: Lean coffee
+        url: /methods/discover/lean-coffee/
+      - name: Stakeholder and user interviews
+        url: /methods/discover/stakeholder-and-user-interviews/
+      - name: Stakeholder influence mapping
+        url: /methods/discover/stakeholder-influence-mapping/
       - name: See all Discover cards
         url: /methods/discover/
   - name: Decide

--- a/_includes/methods/markdown/design-studio.md
+++ b/_includes/methods/markdown/design-studio.md
@@ -1,0 +1,24 @@
+## How to do it
+
+1. Invite between six and 12 participants: stakeholders, users, and team members who need to build a shared understanding. Before the meeting, share applicable research, [user personas]({{ "/methods/decide/personas/" | url }}) (unless users will be present), and the design prompt for the exercise.
+1. Bring drawing materials. At the start of the meeting, review the design prompt and research you shared.
+1. Distribute drawing materials. Ask participants to individually sketch concepts that address the prompt. Remind them that anyone can draw and artistic accuracy is not the goal of the exercise. 15–20 minutes.
+1. Have participants present their ideas to one another in groups of three and solicit critiques.
+1. Ask the groups to create a design that combines the best aspects of members' individual contributions.
+1. Regroup as a whole. Have each group of three present their ideas to everyone. Discuss.
+1. After the meeting, note areas of consistent agreement or disagreement. Incorporate areas of consensus into design recommendations and areas of contention into a research plan.
+
+<section class="method--section method--section--18f-example" markdown="1" >
+
+## Example from 18F
+
+- ["User-centered design at 18F: a design studio for natural resource revenues"](https://18f.gsa.gov/2014/09/25/design-studio-onrr/) Chris Cairns , Michelle Hertzfeld , Nick Bristow.
+
+</section>
+
+<section class="method--section method--section--government-considerations" markdown="1" >
+
+## Considerations for use in government
+
+No PRA implications. If conducted with nine or fewer members of the public, the PRA does not apply, 5 CFR 1320.5(c)4. If participants are employees, the PRA does not apply.
+</section>

--- a/_includes/methods/markdown/dot-voting.md
+++ b/_includes/methods/markdown/dot-voting.md
@@ -1,0 +1,16 @@
+## How to do it
+
+1. Bring plenty of sticky notes and colored stickers to the meeting.
+1. Gather everyone on the product team and anyone with a stake in the product.
+1. Quickly review the project's goals and the conclusions of any prior user research.
+1. Ask team members to take five minutes to write important features or user needs on sticky notes. (One feature per sticky note.)
+1. After five minutes, ask participants to put their stickies on a board. If there are many sticky notes, ask participants to put their features next to similar ones. Remove exact duplicates.
+1. Give participants three to five colored stickers and instruct them to place their stickers on features they feel are most important to meeting the project's goals and user needs. If the group is recently formed, or for other reasons has a low level of established trust and equity, consider a set-up where people can vote privately, e.g. on paper. You’ll need a few extra minutes to compile and display.
+1. Identify the features with the largest number of stickers (votes). Have the team review the voting for whether familiarity bias is resulting in enshrining the status quo.
+
+<section class="method--section method--section--government-considerations" markdown="1" >
+
+## Considerations for use in government
+
+No PRA implications: dot voting falls under "direct observation", which is explicitly exempt from the PRA, 5 CFR 1320(h)3. See the methods for [Recruiting]({{ "/methods/fundamentals/recruiting/" | url }}) and [Privacy]({{ "/methods/fundamentals/privacy/" | url }}) for more tips on taking input from the public.
+</section>

--- a/_includes/methods/markdown/five-whys.md
+++ b/_includes/methods/markdown/five-whys.md
@@ -1,0 +1,28 @@
+## How to do it
+
+Select a particular issue or problem from your user research to investigate further. This could be the most commonly occurring problem or a problem that has been prioritized by the team. 
+Ask why the problem occurred and write down an answer. Repeat this process another four times, building off of the previous response each time to drill down to a root cause. As you probe, make sure you remain sensistive to the emotional response of the interviewee. Sometimes asking why multiple times can cause the interviewee to feel frustrated or defensive if they don’t feel as if they are being heard. See example below:
+
+Starting problem: “We didn’t meet our goal for public feedback during the open comment period.”
+1. *Why?*<br/>
+“Not enough people submitted comments.”
+1. *Why?*<br/>
+“Not enough people made it to the comment submission form.”
+1. *Why?*<br/>
+“The comment submission form was hard to find.”
+1. *Why?*<br/>
+“The link to the comment submission form was buried on the page.”
+1. *Why?*<br/>
+“We didn’t formulate and publish a call to action to submit comments.”
+
+After getting to a root cause, frame or reframe your problem solving approach to address it (e.g., “how might we create a call to action for comment submission?”).
+
+*Note: You may ask “why” more or less than five times during this process. The purpose of this exercise is to help identify what is the root cause.  Ask “why” as many times as needed to get to what you think the root cause is, while keeping the mental cost of the interviewee in mind.*
+
+<section class="method--section method--section--government-considerations" markdown="1" >
+
+## Considerations for use in government
+
+No PRA implications. No information is collected from members of the public.
+
+</section>

--- a/_includes/methods/markdown/heuristic-evaluation.md
+++ b/_includes/methods/markdown/heuristic-evaluation.md
@@ -1,0 +1,24 @@
+## How to do it
+
+1. Recruit a group of three to five people familiar with evaluation methods. These people are not necessarily designers, but are familiar with common usability best practices. They are usually not users.
+1. Ask each person to individually create a list of "heuristics" or general usability best practices. Examples of heuristics from Nielsen's "10 Usability Heuristics for User Interface Design" include:
+    1.  The website should keep users informed about what is going on, through appropriate feedback within reasonable time.
+    1.  The system should speak the user's language, with words, phrases and concepts familiar to the user, rather than system-oriented terms.
+1. Consider what hazards the service or product might hold for its users, and include heuristics to evaluate whether the site protects against possible harms.
+1. Ask each person to evaluate the website against their list and write down possible problems.
+1. After individual evaluations, gather people to discuss what they found and prioritize potential problems.
+
+<section class="method--section method--section--additional-resources" markdown="1">
+
+## Additional resources
+
+- [10 usability heuristics for user interface design — Nielsen Norman Group](https://www.nngroup.com/articles/ten-usability-heuristics/)
+- [USDA Digital strategy tools — Research — Heuristic review template](https://www.usda.gov/digital-strategy/tools)
+</section>
+
+<section class="method--section method--section--government-considerations" markdown="1" >
+
+## Considerations for use in government
+
+No PRA Implications, as heuristic evaluations usually include a small number of evaluators. If conducted with nine or fewer members of the public, the PRA does not apply, 5 CFR 1320.5(c)4. If participants are employees, the PRA does not apply. See the methods for [Recruiting]({{ "/methods/fundamentals/recruiting/" | url }}) and [Privacy]({{ "/methods/fundamentals/privacy/" | url }}) for more tips on taking input from the public.
+</section>

--- a/_includes/methods/markdown/hopes-and-fears.md
+++ b/_includes/methods/markdown/hopes-and-fears.md
@@ -1,0 +1,26 @@
+## How to do it
+
+  1. Ahead of the session, establish what you want to elicit hopes and fears about. For example, you could ask participants to focus on the whole project or that day’s workshop.
+  2. At the beginning of the session, create two columns labeled “Hopes” and “Fears” on a white board or large sticky pad.
+(In a remote setting, you can do this online using collaboration software such as Mural or Google Docs)
+  3. Ask participants to take 1-2 mins to write down their hopes on sticky notes (one hope per sticky note).
+  4. Invite participants to come up one at a time and add their “hopes” sticky notes to the board and say more about what they wrote. Have participants group their sticky notes as they add them to the board to illustrate emerging themes.
+  5. Repeat steps 3 and 4 with fears.
+
+This format can be adapted to include other categories. For example, asking participants to write down skills and experiences can help contextualize each person’s place in the group.
+
+<section class="method--section method--section--18f-example" markdown="1" >
+
+## Example
+
+- [Three small steps you can take to reboot agile in your organization — 18F Blog](https://18f.gsa.gov/2016/10/25/three-small-steps-you-can-take-to-reboot-agile-in-your-organization/)
+
+</section>
+
+
+<section class="method--section method--section--government-considerations" markdown="1" >
+
+## Considerations for use in government
+
+No PRA implications. No information is collected from members of the public.
+</section>

--- a/_includes/methods/markdown/kj-method.md
+++ b/_includes/methods/markdown/kj-method.md
@@ -1,0 +1,21 @@
+## How to do it
+
+1. Gather four or more participants for 90 minutes. Provide sticky notes and markers.
+1. Create a focused question about the project's needs and select a facilitator to run the exercise.
+1. Give participants five minutes to write at least three responses to the question, each on its own note.
+1. Give participants 15 minutes to put their answers on the wall, read everyone else's, and make additions. Have participants cluster similar answers without discussion.
+1. Ask participants to write names for each cluster on their own - this is mandatory. They may also split clusters.
+1. Put each name on the wall by its cluster. Exclude word-for-word duplicates.
+1. Reiterate the question and have each person rank their three most important clusters. Visually tally points.
+1. Combine duplicates and their points if the entire group agrees they're identical. Three or four groups usually rank higher than the rest - these are the priorities for the question.
+
+<section class="method--section method--section--18f-example" markdown="1" >
+
+## Example from 18F
+
+18F conducted this exercise with 20 Federal Election Commission staff members to define priorities around conflicting requests. We used this method to get data from staff (not the decision makers) about what they saw as the most pressing needs. We synthesized and presented the data back to the decision makers.
+</section>
+
+## Considerations for use in government
+
+At 18F, KJ participants are almost always federal employees. If there is any chance your KJ workshop could include participants who are not federal employees, consult OMB guidance on the Paperwork Reduction Act and the Privacy Act. Your agency's Office of General Counsel, and perhaps OIRA desk officers, also can ensure you are following the laws and regulations applicable to federal agencies.

--- a/_includes/methods/markdown/lean-coffee.md
+++ b/_includes/methods/markdown/lean-coffee.md
@@ -1,0 +1,25 @@
+## How to do it
+
+1. Give meeting participants two minutes to write what they would like to talk about on sticky notes (one idea per sticky note)
+1. Have meeting participants review the topics generated and [dot vote]({{ "/methods/discover/dot-voting/" | url }}) on the topics they are most interested in
+1. Decide how much time will be spent talking about each topic
+1. Start with the topic that got the most votes
+1. At the end of the allotted time, have meeting participants vote:
+    - Thumbs up: Continue talking about the topic for a shorter set amount of time
+    - Thumbs down: Move to the next topic
+
+<section class="method--section method--section--18f-example" markdown="1" >
+
+## Example from 18F
+
+At 18F, Lean coffee is often used to facilitate community of practice meetings and team meetings when the objective is to provide a forum for the meeting attendees to raise issues that are of interest to them. This method provides structure to these meetings and ensures topics are democratically selected for conversation.
+
+</section>
+
+<section class="method--section method--section--government-considerations" markdown="1" >
+
+## Considerations for use in government
+
+No PRA implications. No information is collected from members of the public.
+
+</section>

--- a/_includes/methods/markdown/stakeholder-and-user-interviews.md
+++ b/_includes/methods/markdown/stakeholder-and-user-interviews.md
@@ -1,0 +1,24 @@
+## How to do it
+
+  1. Create a guide for yourself of some topics you'd like to ask about, and some specific questions as a back up. Questions will often concern the individual's role, the organization, the individuals' needs, and metrics for success of the project. Consider how the interview could harm the participant, and adjust your questions to avoid those hazards. For example, might your questions trigger thoughts of painful experiences?
+  1. Sit down one-on-one with the participant, or two-on-one with a note-taker or joint interviewer, in a focused environment. Introduce yourself. Explain the premise for the interview as far as you can without biasing their responses.
+  1. Follow the conversation where the participant takes it. They will focus on their priorities and interests. Be comfortable with silences, which allow the participant to elaborate. To keep from getting entirely off course, use your interview guide to make sure you cover what you need to. Ask lots of "why is that" and "how do you do that" questions. Consider asking if there are ways the service or product could cause harm to its users if not done carefully, or what assumptions are being made (leaving it ambiguous as to whether we’re referring to our questions or in the service/product).
+  1. If there are other products they use or your product doesn't have constraints imposed by prior work, observe the stakeholders using a competing product and consider a [comparative analysis]({{ "/methods/decide/comparative-analysis/" | url }}).
+
+<section class="method--section method--section--additional-resources" markdown="1">
+
+## Additional resources
+
+- [Interview checklist]({{ "/methods/interview-checklist/" | url }})
+- [Tips for capturing the best data from user interviews — 18F Blog](https://18f.gsa.gov/2016/02/09/tips-for-capturing-the-best-data-from-user-interviews/)
+- [Build empathy with stakeholder interviews, part 1: Preparation — 18F Blog](https://18f.gsa.gov/2016/06/20/build-empathy-with-stakeholder-interviews-part-1-preparation/)
+- [Build empathy with stakeholder interviews, part 2: Conversation — 18F Blog](https://18f.gsa.gov/2016/07/22/building-empathy-with-stakeholder-interviews-part-2-conversation/)
+
+</section>
+
+<section class="method--section method--section--government-considerations" markdown="1" >
+
+## Considerations for use in government
+
+No PRA implications. The PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3. See the methods for [Recruiting]({{ "/methods/fundamentals/recruiting/" | url }}) and [Privacy]({{ "/methods/fundamentals/privacy/" | url }}) for more tips on taking input from the public.
+</section>

--- a/_includes/methods/markdown/stakeholder-influence-mapping.md
+++ b/_includes/methods/markdown/stakeholder-influence-mapping.md
@@ -1,0 +1,20 @@
+## How to do it
+
+1. Gather the team and, ideally, at least one crucial  stakeholder familiar with their organization and how it works from both a technical and an interpersonal point of view. 
+1. If meeting in person, you’ll need sticky notes and a whiteboard; if meeting remotely, use a virtual whiteboard or tools that support online document collaboration, ideally simultaneously.
+1. Divide the whiteboard into four areas, as a grid. Label the x axis influence and the y axis interest.
+1. List out stakeholders together. Write down names of people, groups, communities, or organizations that your work may impact, and organize them into the four quadrants based on your understanding of their relative influence and interest. 
+1. Look at each quadrant to sort who to engage with and how:
+    - interested and influential - collaborate with them
+    - either influential or interested - keep them informed
+    - neither influential nor interested - allow them to drive their own involvement
+1. If your map reveals power dynamics that route around policy, consider whether the information poses personal or professional risk to any stakeholders. Avoid possible harm by sharing this map with only the people who need to understand it, and consider the consequences of those you do share with — or share an edited version.
+1. Review and update the map as you understand the situation better.
+
+<section class="method--section method--section--18f-example" markdown="1" >
+
+## Considerations for use in government
+
+No PRA implications. No information is collected from members of the public.
+
+</section>

--- a/content/methods/decide/comparative-analysis.md
+++ b/content/methods/decide/comparative-analysis.md
@@ -1,0 +1,5 @@
+---
+title: Comparative analysis
+permalink: /methods/decide/comparative-analysis/
+layout: layouts/page
+---

--- a/content/methods/decide/personas.md
+++ b/content/methods/decide/personas.md
@@ -1,0 +1,5 @@
+---
+title: Personas
+permalink: /methods/decide/personas/
+layout: layouts/page
+---

--- a/content/methods/discover/cognitive-walkthrough.md
+++ b/content/methods/discover/cognitive-walkthrough.md
@@ -14,5 +14,4 @@ method:
   timeRequired: 30 minutes to one hour per person
   category: discover
   content: ./_includes/methods/markdown/cognitive-walkthrough.md
-  last_modified_at: example timestamp
 ---

--- a/content/methods/discover/contextual-inquiry.md
+++ b/content/methods/discover/contextual-inquiry.md
@@ -3,7 +3,7 @@ title: Contextual Inquiry
 permalink: /methods/discover/contextual-inquiry/
 redirect_from:
   - contextual-inquiry/
-layout: layouts/page
+layout: layouts/method-card
 tags: methods
 eleventyNavigation:
   key: methods
@@ -16,5 +16,5 @@ method:
   timeRequired: 1-2 hours per user
   category: discover
   content: ./_includes/methods/markdown/contextual-inquiry.md
-  last_modified_at:
+  last_modified_at: example timestamp
 ---

--- a/content/methods/discover/contextual-inquiry.md
+++ b/content/methods/discover/contextual-inquiry.md
@@ -16,5 +16,4 @@ method:
   timeRequired: 1-2 hours per user
   category: discover
   content: ./_includes/methods/markdown/contextual-inquiry.md
-  last_modified_at: example timestamp
 ---

--- a/content/methods/discover/design-studio.md
+++ b/content/methods/discover/design-studio.md
@@ -1,0 +1,20 @@
+---
+title: Design studio
+permalink: /methods/discover/design-studio/
+layout: layouts/method-card
+tags: methods
+redirect_from:
+  - design-studio/
+eleventyNavigation:
+  key: methods
+  parent: Discover
+  title: Design studio
+method:
+  title: Design studio
+  what: An illustration-based way to facilitate communication (and brainstorming) between a project team and stakeholders.
+  why: To create a shared understanding and appreciation of design problems confronting the project team.
+  timeRequired: 3–4 hours
+  category: discover
+  content: ./_includes/methods/markdown/design-studio.md
+  last_modified_at: example timestamp
+---

--- a/content/methods/discover/design-studio.md
+++ b/content/methods/discover/design-studio.md
@@ -16,5 +16,4 @@ method:
   timeRequired: 3–4 hours
   category: discover
   content: ./_includes/methods/markdown/design-studio.md
-  last_modified_at: example timestamp
 ---

--- a/content/methods/discover/dot-voting.md
+++ b/content/methods/discover/dot-voting.md
@@ -18,5 +18,4 @@ method:
   timeRequired: 15 minutes
   category: discover
   content: ./_includes/methods/markdown/dot-voting.md
-  last_modified_at: example timestamp
 ---

--- a/content/methods/discover/dot-voting.md
+++ b/content/methods/discover/dot-voting.md
@@ -1,0 +1,22 @@
+---
+title: Dot voting
+permalink: /methods/discover/dot-voting/
+redirect_from:
+  - discover/feature-dot-voting/
+  - feature-dot-voting/
+  - dot-voting/
+layout: layouts/method-card
+tags: methods
+eleventyNavigation:
+  key: methods
+  parent: Discover
+  title: Dot voting
+method:
+  title: Dot voting
+  what: A simple voting exercise to identify a group's collective priorities.
+  why: To reach a consensus on priorities of subjective, qualitative data with a group of people. This is especially helpful with larger groups of stakeholders and groups with high risk of disagreement.
+  timeRequired: 15 minutes
+  category: discover
+  content: ./_includes/methods/markdown/dot-voting.md
+  last_modified_at: example timestamp
+---

--- a/content/methods/discover/five-whys.md
+++ b/content/methods/discover/five-whys.md
@@ -16,5 +16,4 @@ method:
   timeRequired: Less than 1 hour
   category: discover
   content: ./_includes/methods/markdown/five-whys.md
-  last_modified_at: example timestamp
 ---

--- a/content/methods/discover/five-whys.md
+++ b/content/methods/discover/five-whys.md
@@ -1,0 +1,20 @@
+---
+title: Five whys
+permalink: /methods/discover/five-whys/
+redirect_from:
+  - five-whys/
+layout: layouts/method-card
+tags: methods
+eleventyNavigation:
+  key: methods
+  parent: Discover
+  title: Five whys
+method:
+  title: Five whys
+  what: An iterative process for identifying the root cause of a problem by posing the question “Why?” at least five times to help separate symptoms from causes.
+  why: To identify the root cause(s) of an issue or problem.
+  timeRequired: Less than 1 hour
+  category: discover
+  content: ./_includes/methods/markdown/five-whys.md
+  last_modified_at: example timestamp
+---

--- a/content/methods/discover/heuristic-evaluation.md
+++ b/content/methods/discover/heuristic-evaluation.md
@@ -18,5 +18,4 @@ method:
   timeRequired: 1–2 hours
   category: discover
   content: ./_includes/methods/markdown/heuristic-evaluation.md
-  last_modified_at: example timestamp
 ---

--- a/content/methods/discover/heuristic-evaluation.md
+++ b/content/methods/discover/heuristic-evaluation.md
@@ -1,0 +1,22 @@
+---
+title: Heuristic evaluation
+permalink: /methods/discover/heuristic-evaluation/
+redirect_from:
+  - discover/heuristic-analysis/
+  - heuristic-evaluation/
+  - heuristic-analysis/
+layout: layouts/method-card
+tags: methods
+eleventyNavigation:
+  key: methods
+  parent: Discover
+  title: Heuristic evaluation
+method:
+  title: Heuristic evaluation
+  what: A quick way to find common, large usability problems on a website.
+  why: To quickly identify common design problems that make websites hard to use without conducting more involved user research.
+  timeRequired: 1–2 hours
+  category: discover
+  content: ./_includes/methods/markdown/heuristic-evaluation.md
+  last_modified_at: example timestamp
+---

--- a/content/methods/discover/hopes-and-fears.md
+++ b/content/methods/discover/hopes-and-fears.md
@@ -1,0 +1,20 @@
+---
+title: Hopes and fears
+permalink: /methods/discover/hopes-and-fears/
+redirect_from:
+  - hopes-and-fears/
+layout: layouts/method-card
+tags: methods
+eleventyNavigation:
+  key: methods
+  parent: Discover
+  title: Hopes and fears
+method:
+  title: Hopes and fears
+  what: An exercise that quickly surfaces a group’s hopes and fears for the future
+  why: To establish a baseline understanding of a group’s expectations and concerns about a project and to give each person an opportunity to voice their perspective
+  timeRequired: 30–60 mins
+  category: discover
+  content: ./_includes/methods/markdown/hopes-and-fears.md
+  last_modified_at: example timestamp
+---

--- a/content/methods/discover/hopes-and-fears.md
+++ b/content/methods/discover/hopes-and-fears.md
@@ -16,5 +16,4 @@ method:
   timeRequired: 30–60 mins
   category: discover
   content: ./_includes/methods/markdown/hopes-and-fears.md
-  last_modified_at: example timestamp
 ---

--- a/content/methods/discover/kj-method.md
+++ b/content/methods/discover/kj-method.md
@@ -16,5 +16,4 @@ method:
   timeRequired: 1–2 hours
   category: discover
   content: ./_includes/methods/markdown/kj-method.md
-  last_modified_at: example timestamp
 ---

--- a/content/methods/discover/kj-method.md
+++ b/content/methods/discover/kj-method.md
@@ -1,0 +1,20 @@
+---
+title: KJ method
+permalink: /methods/discover/kj-method/
+redirect_from:
+  - kj-method/
+layout: layouts/method-card
+tags: methods
+eleventyNavigation:
+  key: methods
+  parent: Discover
+  title: KJ method
+method:
+  title: KJ method
+  what: A facilitated exercise in which participants list their individual priorities onto cards, collect them as a group, organize them by relationship, and establish group priorities through individual voting.
+  why: To reach a consensus on priorities of subjective, qualitative data with a group of people. This is especially helpful with larger groups of stakeholders and groups with high risk of disagreement.
+  timeRequired: 1–2 hours
+  category: discover
+  content: ./_includes/methods/markdown/kj-method.md
+  last_modified_at: example timestamp
+---

--- a/content/methods/discover/lean-coffee.md
+++ b/content/methods/discover/lean-coffee.md
@@ -16,5 +16,4 @@ method:
   timeRequired: Flexible
   category: discover
   content: ./_includes/methods/markdown/lean-coffee.md
-  last_modified_at: example timestamp
 ---

--- a/content/methods/discover/lean-coffee.md
+++ b/content/methods/discover/lean-coffee.md
@@ -1,0 +1,20 @@
+---
+title: Lean coffee
+permalink: /methods/discover/lean-coffee/
+redirect_from:
+  - lean-coffee/
+layout: layouts/method-card
+tags: methods
+eleventyNavigation:
+  key: methods
+  parent: Discover
+  title: Lean coffee
+method:
+  title: Lean coffee
+  what: A format for running a meeting without a predefined agenda
+  why: To give everyone equal opportunity to surface ideas and vote on agenda topics,  allowing meeting attendees to be co-owners in the meeting agenda.
+  timeRequired: Flexible
+  category: discover
+  content: ./_includes/methods/markdown/lean-coffee.md
+  last_modified_at: example timestamp
+---

--- a/content/methods/discover/stakeholder-and-user-interviews.md
+++ b/content/methods/discover/stakeholder-and-user-interviews.md
@@ -1,0 +1,20 @@
+---
+title: Stakeholder and user interviews
+permalink: /methods/discover/stakeholder-and-user-interviews/
+redirect_from:
+  - stakeholder-and-user-interviews/
+layout: layouts/method-card
+tags: methods
+eleventyNavigation:
+  key: methods
+  parent: Discover
+  title: Stakeholder and user interviews
+method:
+  title: Stakeholder and user interviews
+  what: A wide-spanning set of semi-structured interviews with living experts who have an interest in a project's success, including stakeholders and users.
+  why: To build consensus about the problem statement and research objectives.
+  timeRequired: 1–2 hours per interviewee
+  category: discover
+  content: ./_includes/methods/markdown/stakeholder-and-user-interviews.md
+  last_modified_at: example timestamp
+---

--- a/content/methods/discover/stakeholder-and-user-interviews.md
+++ b/content/methods/discover/stakeholder-and-user-interviews.md
@@ -16,5 +16,4 @@ method:
   timeRequired: 1–2 hours per interviewee
   category: discover
   content: ./_includes/methods/markdown/stakeholder-and-user-interviews.md
-  last_modified_at: example timestamp
 ---

--- a/content/methods/discover/stakeholder-influence-mapping.md
+++ b/content/methods/discover/stakeholder-influence-mapping.md
@@ -1,0 +1,20 @@
+---
+title: Stakeholder influence mapping
+permalink: /methods/discover/stakeholder-influence-mapping/
+redirect_from:
+  - stakeholder-influence-mapping/
+layout: layouts/method-card
+tags: methods
+eleventyNavigation:
+  key: methods
+  parent: Discover
+  title: Stakeholder influence mapping
+method:
+  title: Stakeholder influence mapping
+  what: A visual representation of stakeholders — the people who are involved — and their potential influence and impact on a project or service system, in comparison to one another.
+  why: To uncover and describe power dynamics — the often-unspoken balances of influence and control — that could impact project outcomes; prioritize which stakeholders to engage with and how, and inform a communication and engagement approach.
+  timeRequired: ~1 hour
+  category: discover
+  content: ./_includes/methods/markdown/stakeholder-influence-mapping.md
+  last_modified_at: example timestamp
+---

--- a/content/methods/discover/stakeholder-influence-mapping.md
+++ b/content/methods/discover/stakeholder-influence-mapping.md
@@ -16,5 +16,4 @@ method:
   timeRequired: ~1 hour
   category: discover
   content: ./_includes/methods/markdown/stakeholder-influence-mapping.md
-  last_modified_at: example timestamp
 ---

--- a/content/methods/interview-checklist.md
+++ b/content/methods/interview-checklist.md
@@ -1,0 +1,5 @@
+---
+title: Interview checklist
+permalink: /methods/interview-checklist/
+layout: layouts/page
+---


### PR DESCRIPTION
Changed link style from `<a>` to markdown `[]()` for consistency

Roughs in three pages to prevent broken links:
- comparative analysis
- personas
- interview checklist

A portion of #234 