### PR TITLE
Initial methods landing page

### DIFF
--- a/_data/method_categories.yaml
+++ b/_data/method_categories.yaml
@@ -1,66 +1,29 @@
 discover:
-  category_name: Discover
-  category_description: Build a greater understanding of your problem and the people it impacts.
-  category_info: Use the Discover Methods to build context for the problem you’re investigating. Get to know your potential users better and understand your stakeholders’ main concerns. The work you do during this phase will inform everything that follows, so take your time.
-  methods:
-    - Cognitive walkthrough
-    - Contextual inquiry
-    - Design studio
-    - Dot voting
-    - Five whys
-    - Heuristic evaluation
-    - Hopes and fears
-    - KJ method
-    - Lean coffee
-    - Stakeholder and user interviews
-    - Stakeholder influence mapping
+  path: /methods/discover/
+  name: Discover
+  description: Build a greater understanding of your problem and the people it impacts.
+  info: Use the Discover Methods to build context for the problem you’re investigating. Get to know your potential users better and understand your stakeholders’ main concerns. The work you do during this phase will inform everything that follows, so take your time.
 
 decide:
-  category_name: Decide
-  category_description: Elaborate on research from your Discovery phase.
-  category_info: The Decide Methods help you derive insights from the information gathered during the Discovery phase. You’ll validate initial assumptions, develop a deeper understanding of workflows and processes, and develop design hypotheses.
-  methods:
-    - Affinity mapping
-    - Comparative analysis
-    - Content audit
-    - Design hypothesis
-    - Design principles
-    - Interface audit
-    - Journey mapping
-    - Mental modeling
-    - Personas
-    - Service blueprint
-    - Site mapping
-    - Storyboarding
-    - Style tiles
-    - Task flow analysis
-    - User scenarios
+  path: /methods/decide/
+  name: Decide
+  description: Elaborate on research from your Discovery phase.
+  info: The Decide Methods help you derive insights from the information gathered during the Discovery phase. You’ll validate initial assumptions, develop a deeper understanding of workflows and processes, and develop design hypotheses.
 
 make:
-  category_name: Make
-  category_description: Create a testable solution.
-  category_info: Once you’ve learned more about your users’ expectations, use the Make Methods to create testable designs. Sketching, wireframing, and prototyping will help you ensure your product reflects your users’ needs.
-  methods:
-    - Design pattern library
-    - Prototyping
-    - Wireframing
+  path: /methods/make/
+  name: Make
+  description: Create a testable solution.
+  info: Once you’ve learned more about your users’ expectations, use the Make Methods to create testable designs. Sketching, wireframing, and prototyping will help you ensure your product reflects your users’ needs.
 
 validate:
-  category_name: Validate
-  category_description: Test a design hypothesis.
-  category_info: Testing (and re-testing) your designs with users will help you build the best possible product. Our Validate Methods cover varied testing scenarios and potential user groups.
-  methods:
-    - Card sorting
-    - Multivariate testing
-    - Usability testing
-    - Visual preference testing
+  path: /methods/validate/
+  name: Validate
+  description: Test a design hypothesis.
+  info: Testing (and re-testing) your designs with users will help you build the best possible product. Our Validate Methods cover varied testing scenarios and potential user groups.
 
 fundamentals:
-  category_name: Fundamentals
-  category_description: Foundational methods for practicing design research.
-  category_info: Our Fundamentals Methods, which combine government-specific protocols and industry best practices, lay the groundwork for successful research, no matter what you’re testing. For best results, review them before you start recruiting.
-  methods:
-  - Compensation
-  - Privacy
-  - Recruiting
-
+  path: /methods/fundamentals/
+  name: Fundamentals
+  description: Foundational methods for practicing design research.
+  info: Our Fundamentals Methods, which combine government-specific protocols and industry best practices, lay the groundwork for successful research, no matter what you’re testing. For best results, review them before you start recruiting.

--- a/_includes/layouts/method-card.html
+++ b/_includes/layouts/method-card.html
@@ -6,7 +6,7 @@ layout: layouts/default
   <header class="category--header" aria-labelledby="{{method_category.title | downcase }}">
     <div class="grid-container">
       <span class="category--title" id="{{method_category.title | downcase }}">{{ method.category | capitalize }}</span>
-      <p class="category--subtitle">{{ method_categories[method.category].category_description }}</p>
+      <p class="category--subtitle">{{ method_categories[method.category].description }}</p>
     </div>
   </header>
   <div class="grid-container">

--- a/_includes/layouts/method-category.html
+++ b/_includes/layouts/method-category.html
@@ -6,7 +6,7 @@ layout: layouts/default
   <header class="category--header">
     <div class="grid-container">
       <h1 class="category--title">{{ category | capitalize }}</h1>
-      <p class="category--subtitle">{{ method_categories[category].category_description }}</p>
+      <p class="category--subtitle">{{ method_categories[category].description }}</p>
     </div>
   </header>
   <div class="grid-container">

--- a/_includes/methods/homepage-category.html
+++ b/_includes/methods/homepage-category.html
@@ -8,9 +8,6 @@
         <a href="{{ category.path | url }}" class="usa-link a-see-all">See all {{ category.name | downcase }} methods</a>
       </div>
     </div>
-    <div class="grid-col-4 methods-listing">
-      <h3>Methods include</h3>
-      {% include "methods/homepage-methods-include.html" category_slug: category_slug %}
-    </div>
+    <div class="grid-col-4 methods-listing"><h3>Methods include</h3>{% include "methods/homepage-methods-include.html" category_slug: category_slug %}</div>
   </div>
 </section>

--- a/_includes/methods/homepage-category.html
+++ b/_includes/methods/homepage-category.html
@@ -1,0 +1,16 @@
+<section class="usa-prose grid-container category usa-section category--{{ category_slug }}" id="{{ category_slug }}">
+  <h2 class="category--title category--{{ category.name | downcase }}--title">{{ category.name }}</h2>
+  <div class="grid-row">
+    <div class="grid-col-8">
+      <div class="category--header usa-content">
+        <p class="category--subtitle">{{ category.description }}</p>
+        <p>{{ category.info }}</p>
+        <a href="{{ category.path | url }}" class="usa-link a-see-all">See all {{ category.name | downcase }} methods</a>
+      </div>
+    </div>
+    <div class="grid-col-4 methods-listing">
+      <h3>Methods include</h3>
+      {% include "methods/homepage-methods-include.html" category_slug: category_slug %}
+    </div>
+  </div>
+</section>

--- a/_includes/methods/homepage-methods-include.html
+++ b/_includes/methods/homepage-methods-include.html
@@ -1,0 +1,9 @@
+<ul class="usa-list">
+{% for method_page in collections.methods %}
+{% if method_page.data.method.category == category_slug %}
+  <li>
+    <a href="{{ method_page.data.permalink | url }}" class="usa-link">{{ method_page.data.method.title }}</a>
+  </li>
+{% endif %}
+{% endfor %}
+</ul>

--- a/assets/methods/styles/_category.scss
+++ b/assets/methods/styles/_category.scss
@@ -60,8 +60,6 @@
 }
 
 
-
-
 .layout--methods {
   .category {
     background-color: #fff;
@@ -135,10 +133,12 @@
     .method-listing {
       li {
         margin-bottom: .5rem;
+        list-style-type: none;
       }
     }
   }
 }
+
 
 
 @media screen and (max-width: 600px) {
@@ -154,4 +154,3 @@
     }
   }
 }
-

--- a/assets/methods/styles/_homepage.scss
+++ b/assets/methods/styles/_homepage.scss
@@ -1,0 +1,28 @@
+/*
+a bunch of random things needed for
+the methods landing page only
+*/
+
+.methods-listing {
+  ul {
+    padding-left: 0;
+    list-style-type: none;
+  }
+}
+
+.visually-hidden {
+  position: absolute !important;
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+  clip: rect(1px 1px 1px 1px);
+  clip: rect(1px, 1px, 1px, 1px);
+}
+
+.usa-intro--methods {
+  font-size: 2.03rem;
+  font-weight: bold;
+  line-height: 1.3;
+  max-width: 44ex;
+  margin: 0;
+}

--- a/assets/methods/styles/methods-styles.scss
+++ b/assets/methods/styles/methods-styles.scss
@@ -17,3 +17,4 @@ Custom styling for methods guide only
 @forward "methods-colors";
 @forward "category";
 @forward "method";
+@forward "homepage";

--- a/content/methods/fundamentals/compensation.md
+++ b/content/methods/fundamentals/compensation.md
@@ -7,6 +7,7 @@ eleventyNavigation:
   key: methods
   parent: Fundamentals
   title: Compensation
+eleventyExcludeFromCollections: true
 ---
 
 

--- a/content/methods/index.md
+++ b/content/methods/index.md
@@ -1,8 +1,27 @@
 ---
 title: methods homepage
 permalink: /methods/
-layout: layouts/page
+layout: layouts/default
 tags: methods
 ---
 
-hello world
+<div class="usa-section intro-header">
+  <div class="grid-container">
+    <h1 class="visually-hidden">
+      {{ title }}
+    </h1>
+    <p class="usa-intro usa-intro--methods no-print">A collection of tools to bring human-centered design into your project.</p>
+  </div>
+</div>
+<div class="usa-section layout--methods">
+{% for obj in method_categories %}
+  {% comment %}
+    methods_categories is a hash, so the object in the iteration is a key/values array.
+    obj[0] is the key, which can be used as a slugified version of the category name.
+    obj[1] is the category values object.
+  {% endcomment %}
+  {% assign category_slug = obj[0] %}
+  {% assign category = obj[1] %}
+  {% include "methods/homepage-category.html" category_slug: category_slug category: category %}
+{% endfor %}
+</div>

--- a/content/methods/make/design-pattern-library.md
+++ b/content/methods/make/design-pattern-library.md
@@ -7,6 +7,7 @@ eleventyNavigation:
   key: methods
   parent: Make
   title: Design pattern library
+eleventyExcludeFromCollections: true
 ---
 
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adds content and styling for methods landing page: `/methods/`
- Cleans up methods categories data—listing of each method for each category wasn't needed, and `category_` on keys was redundant

Same known issues as in https://github.com/18F/guides/pull/273

Closes #233

## security considerations

None
