### PR TITLE
Add interview checklist and debrief pages

### DIFF
--- a/content/methods/interview-checklist.md
+++ b/content/methods/interview-checklist.md
@@ -2,4 +2,108 @@
 title: Interview checklist
 permalink: /methods/interview-checklist/
 layout: layouts/page
+tags: methods
 ---
+
+<style type="text/css" media="print">
+@page {
+  margin: 1in;
+}
+</style>
+
+[Stakeholder and user interviews]({{ "/methods/discover/stakeholder-and-user-interviews/" | url }}) often progress through key moments: introductions lead to warm-up questions, which lead to topic-specific questions, activities, etc. This checklist outlines those key moments, and suggests things to do as you go through them. GSA Staff, please see this [Google Doc Template](https://docs.google.com/document/d/1zRA2EK9qZ5H_cM3Ki5xf6Gz72F6Ah6i0E87YpwHTC9A/edit)
+
+
+## Pre-interview preparation
+**Set aside 10 minutes** before the interview begins to help your team intentionally transition to an inquiring mindset, to clarify with your colleagues their respective roles, to check any technologies on which the interview will rely, etc.
+
+### Make sure to
+- [ ] Remind your team of the purpose of the interview
+- [ ] Establish clear roles for anyone who will join (for example, moderators, observers, notetakers, etc.).
+- [ ] Confirm with teammates, especially remote ones, how they might ask questions during the interview (for example, in a Slack thread)
+- [ ] Do a tech check: confirm that screen sharing, recording, etc. works
+- [ ] Check receipt of a signed participant agreement ([example]({{ "/ux-guide/participant-agreement/" | url }}))
+- [ ] Double-check any links, files, etc. that participants will need to evaluate (i.e., ensure that your concept, wireframes, or prototypes are available for testing)
+
+
+## Introductions
+**Spend 5 minutes** at the beginning of the interview to clarify with the participant the parameters of the interview, and to give them a chance to ask any logistics-related questions.
+
+### Make sure to
+- [ ] Thank the participant for their time
+- [ ] Introduce yourself, and anyone who is joining you
+- [ ] Explain the purpose of your research
+- [ ] Provide an overview of the shape of the interview, including any required logistics (for example, screen sharing)
+- [ ] Confirm the expected length of the interview
+- [ ] Confirm receipt of a signed participant agreement ([example]({{  "/ux-guide/participant-agreement/" | url }}))
+- [ ] Explain
+  - [ ] How you’ll take notes (for example, video recording).
+  - [ ] How you’ll use any notes you take (for example, unattributed quotes)
+- [ ] Ask the participant if they have questions at this time
+- [ ] If the participant consents, turn on the recorder
+
+
+## Warm-up / icebreaker
+**Spend 5-10 minutes** establishing the cadence for the interview as a conversation rather than a stilted back and forth. Help the participant feel comfortable, and focus on gaining important context for the body of the interview.
+
+### Make sure to
+
+- [ ] Be polite; you’re a guest in the participant’s world
+- [ ] Give the participant your full attention (You can signal this by making eye contact, asking follow up questions, etc. Be aware that taking notes, especially on a laptop, can distract from the conversation itself)
+- [ ] Ask open-ended questions that will give you relevant information and help you form a better understanding of who this person is
+- [ ] Understand the degree to which this person is comfortable talking about themselves and their work, and at what speed. Be mindful and respectful of anything the the participant is uncomfortable talking about
+- [ ] Give the participant time to respond; don’t be afraid of awkward pauses
+- [ ] Ask for a “tour”: note any organizations, tools, rituals, or processes that affect your participant’s perspective
+- [ ] Start broad (“So to start, could you tell us how you got into this line of work?” or “What’s a day in your work-life like?”), and then slowly direct the interview toward any planned activities (“Could you share your screen and show me how you do that?”) or topic-specific questions (“How often do you file TPS reports?”)
+
+
+## Activities or topic-specific questions
+**Spend 25 minutes** exploring the topics or leading the participant through the activities (for example, screen sharing) the research was designed around.
+
+### Make sure to
+- [ ] Know what you want to learn
+- [ ] Demonstrate genuine curiosity
+- [ ] Let the conversation flow naturally, and try and get the participant to tell stories — yes, stories — related to the things you’re studying
+- [ ] Default to open-ended questions such as “Tell me about a time… ”, “Can you explain…”, “Why do you think…”
+- [ ] Ask clarifying questions or ask your interviewee to repeat themselves if you missed something
+- [ ] Use a diverse array of question types, such as context-gathering questions (asking about sequences of events, relationships, etc.), clarification questions, and comparison/contrasting questions
+- [ ] Use transition phrases to help participants understand when you are moving between parts of the interview (“let’s go back to something you said before”)
+- [ ] Test your own assumptions and understandings without asking leading questions. Ask “how” and “why” multiple times, and give the participant sufficient time to think about their answers
+- [ ] Note the exact words and phrases people use. Don’t correct them, even their pronunciation, if you think they’re wrong
+- [ ] Look people in the eye and give positive affirmations. Lean forward. Say things like “Wow,” or “Oh, interesting!” (when those reactions genuinely occur to you, of course)
+- [ ] If you ask the participant to share their screen
+  - [ ] Caution them to close anything they don't want recorded beforehand
+  - [ ] Assure them that there are no wrong answers — you’re testing the design, not them
+  - [ ] Ask them to think out loud
+  - [ ] Ask “How would you expect this to work?”
+- [ ] Periodically check to see if your teammates have any questions
+
+
+## Wrap-up
+**Spend 5 minutes** thanking the participant, communicating any next steps, and giving the participant a chance to ask any questions they might have.
+
+### Make sure to
+- [ ] Thank the participant for their time and reiterate the value of their contributions
+- [ ] Ask the participant if there was anything they think we missed or that they would like to add
+- [ ] Ask if it would be okay to contact them again with any follow up questions
+- [ ] Provide any agreed-upon [compensation]({{ "/methods/fundamentals/compensation/" | url }})
+- [ ] Turn off the recorder
+- [ ] If possible, ensure the participant that they will receive a copy of what you’ve found during the research (so they know what happened with the input they gave)
+- [ ] If desired, ask them who else you might talk to (fun fact: this is called snowball sampling)
+
+## Post-interview activities
+Once the interview is complete, **spend 15 minutes** completing a post-interview debrief. Tend to any post-interview logistics.
+
+### Make sure to
+- [ ] If you’ve recorded the interview: Move any recordings from your Google Drive to the project folder
+- [ ] Engage the team in a post-interview debrief ([example]({{ "/methods/interview-debrief/" | url }})) to discuss surprises and reflect on what you heard
+- [ ] Consider updating the interview guide based on this interview
+- [ ] If you promised the participant any follow-up communications, identify who will send them and when
+- [ ] Optional: Update your study contact list
+
+
+### Contributors
+Amy Ashida, Julia Lindpaintner, Andrew Maier, Victor Udoewa
+
+### References
+Interviewing Users by Steve Portigal; Practical Ethnography by Sam Ladner

--- a/content/methods/interview-debrief.md
+++ b/content/methods/interview-debrief.md
@@ -1,0 +1,40 @@
+---
+title: Example Interview Debrief Worksheet
+permalink: /methods/interview-debrief/
+layout: layouts/page
+tags: methods
+---
+
+<style type="text/css" media="print">
+@page {
+  margin: 1in;
+}
+</style>
+
+The following questions are provided as useful starting points for facilitating post-moderated research conversation (for example, after a [stakeholder or user interview]({{ "/methods/discover/stakeholder-and-user-interviews/" | url }}), or a [usability test]({{ "/methods/validate/usability-testing/" | url }}). We recommend copying the questions to collaborative writing tool and giving the team four minutes per section to respond, and then facilitating a section-wise discussion. GSA Staff, please see this [Google Doc Template](https://docs.google.com/document/d/1f5Ue2vbeg4-95EevvlURzvl6yMLwMOXtiNwe6OMnb9E/edit#).
+
+## Warm up (4 minutes)
+
+- What stood out about this interview?
+- What are this participant’s goals? What matters to them?
+- What are their challenges or unmet needs?
+- What stories did this participant tell?
+
+## Concept test or demo (4 minutes)
+
+- What goal or task-oriented stories did this participant tell?
+- What words did the participant use to describe what they shared?
+- What aspects of the participant's task performance went well?
+- What aspects of the participant's task performance went poorly?
+
+## Retrospective (4 minutes)
+
+- What about this session reminded you of past sessions (if applicable)?
+- What went well about this session?
+- What went poorly (for example, uncomfortable topics, awkward transitions, etc.)?
+- How might the interview guide (or, if applicable wireframe or prototype) be updated before the next session?
+
+
+### References
+
+- [Example Debriefing Worksheet from Portigal Consulting](https://rosenfeldmedia.com/wp-content/uploads/2014/10/Portigal-Consulting-Debriefing-Worksheet-2.pdf)

--- a/content/methods/validate/usability-testing.md
+++ b/content/methods/validate/usability-testing.md
@@ -1,0 +1,11 @@
+---
+title: Usability testing
+permalink: /methods/validate/usability-testing/
+layout: layouts/page
+tags: methods
+eleventyNavigation:
+  key: methods
+  parent: Validate
+  title: Usability testing
+eleventyExcludeFromCollections: true
+---


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adds `/methods/interview-checklist/` and `/methods/interview-debrief` pages, along with stubbed out pages that are linked from these pages.

## security considerations

None
