### PR TITLE
Add print page and styling for methods

### DIFF
--- a/_includes/layouts/methods-print.html
+++ b/_includes/layouts/methods-print.html
@@ -1,0 +1,28 @@
+---
+layout: layouts/default
+---
+
+{% for obj in method_categories %}
+  {% assign category_slug = obj[0] %}
+  {% assign category = obj[1] %}
+  <section class="category category--{{ category.name | downcase }} usa-section usa-prose" id="{{ category.name | downcase }}">
+    <header class="category--header">
+      <div class="grid-container">
+        <h1 class="category--title">{{ category.name | capitalize }}</h1>
+        <p class="category--subtitle">{{category.description }}</p>
+      </div>
+    </header>
+    <div class="grid-container">
+      {% for method_page in collections.methods %}
+        {% if method_page.data.method.category == category_slug %}
+          {%- include "methods/method.html" this_method: method_page.data.method -%}
+        {% endif %}
+      {% endfor %}
+      {%- include "methods/return-to-top.html" -%}
+    </div>
+  </section>
+{% endfor %}
+
+<script type="text/javascript">
+  window.onload = print();
+</script>

--- a/_includes/methods/markdown/affinity-mapping.md
+++ b/_includes/methods/markdown/affinity-mapping.md
@@ -1,4 +1,4 @@
-## How to do it
+## How to do it{#how-to-affinity-mapping}
 
 1. Record ideas, quotes, or observations from [interviews]({{ "/methods/discover/stakeholder-and-user-interviews/" | url }}), [contextual inquiry]({{ "/methods/discover/contextual-inquiry/" | url }}), or other sources of research on sticky notes.
 1. Place the sticky notes on a white board (in no particular arrangement). Move the sticky notes into related groups.
@@ -6,7 +6,7 @@
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government
+## Considerations for use in government{#consideration-affinity-mapping}
 
 No PRA implications. This method may use data gathered from members of the public, but does not require their involvement.
 </section>

--- a/_includes/methods/markdown/card-sorting.md
+++ b/_includes/methods/markdown/card-sorting.md
@@ -1,21 +1,21 @@
-## How to do it
+## How to do it{#how-to-card-sort}
 
 There are two types of card sorting: open and closed. Most card sorts are performed with one user at a time, but you can also do the exercise with groups of two to three people.
 
-### Open card sort
+### Open card sort{#open-card-sort}
 1. Give users a collection of content represented on cards.
 1. Ask users to separate the cards into whatever categories make sense to them.
 1. Ask users to label those categories.
 1. Ask users to tell you why they grouped the cards and labeled the categories as they did.
 
-### Closed card sort
+### Closed card sort{#closed-card-sort}
 1. Give users a collection of content represented on cards.
 1. Ask users to separate the cards into a list of categories you have predefined.
 1. Ask users to tell you why they assigned cards to the categories they did.
 
 <section class="method--section method--section--18f-example" markdown="1" >
 
-## Example from 18F
+## Example from 18F{#ex-card-sort}
 
 - [Research plan including card sorting from 18F’s C2 project — 18F GitHub](https://github.com/18F/C2/wiki/Sprint-5:-Interaction-model-June-2016)
 
@@ -23,7 +23,7 @@ There are two types of card sorting: open and closed. Most card sorts are perfor
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government
+## Considerations for use in government{#con-card-sort}
 
 No PRA implications if done as directly moderated sessions. The PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3.
 </section>

--- a/_includes/methods/markdown/cognitive-walkthrough.md
+++ b/_includes/methods/markdown/cognitive-walkthrough.md
@@ -1,4 +1,4 @@
-## How to do it
+## How to do it{#how-to-cog-walkthrough}
 
 1. Identify specific traits for new or infrequent users of a design solution.
 1. Develop a set of representative tasks that emphasize new use or infrequent use.
@@ -11,7 +11,7 @@
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government
+## Considerations for use in government{#considerations-cog-walkthrough}
 
 No PRA implications. The PRA explicitly exempts direct observation and non-standardized conversation (e.g., not a survey) that a cognitive walkthrough entails, 5 CFR 1320.3(h)3.
 

--- a/_includes/methods/markdown/comparative-analysis.md
+++ b/_includes/methods/markdown/comparative-analysis.md
@@ -1,4 +1,4 @@
-## How to do it
+## How to do it{#how-to-comparative-analysis}
 
 1. Identify a list of services that would be either direct or related competitors to your service.  Pare the list down to four or five.
 1. Establish which criteria or heuristics you will use to evaluate each competing service.
@@ -8,7 +8,7 @@
 
 <section class="method--section method--section--18f-example" markdown="1" >
 
-## Example from TTS
+## Example from TTS{#example-comparative-analysis}
 
 - [Draft U.S. Web Design Standards comparative analysis — USWDS GitHub](https://github.com/18F/web-design-standards/wiki/Comparative-Analysis)
 
@@ -16,7 +16,7 @@
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government
+## Considerations for use in government{#considerations-comparative-analysis}
 
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/_includes/methods/markdown/compensation.md
+++ b/_includes/methods/markdown/compensation.md
@@ -1,4 +1,3 @@
-
 ## How to do it{#how-to-compensation}
 
 1. Figure out what's legal and appropriate. Consult your agency's Office of General Counsel on options for providing compensation to encourage participation in usability testing, consistent with your agency's authorities. The options will depend upon your agency's authorities and the specific facts.

--- a/_includes/methods/markdown/compensation.md
+++ b/_includes/methods/markdown/compensation.md
@@ -1,4 +1,5 @@
-## How to do it
+
+## How to do it{#how-to-compensation}
 
 1. Figure out what's legal and appropriate. Consult your agency's Office of General Counsel on options for providing compensation to encourage participation in usability testing, consistent with your agency's authorities. The options will depend upon your agency's authorities and the specific facts.
 1. Consider contracting for a recruiting service to help you get an effective research pool.
@@ -6,7 +7,7 @@
 
 <section class="method--section method--section--18f-example" markdown="1">
 
-## Example
+## Example{#example-compensation}
 
 - [Compensating research participants — TTS Handbook](https://handbook.tts.gsa.gov/18f/how-18f-works/research-guidelines/#compensating-user-research-participants)
 
@@ -14,7 +15,7 @@
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government
+## Considerations for use in government{#considerations-compensation}
 
 No PRA implications. Even when users are present, the PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3.
 

--- a/_includes/methods/markdown/content-audit.md
+++ b/_includes/methods/markdown/content-audit.md
@@ -1,4 +1,4 @@
-## How to do it
+## How to do it{#how-content-audit}
 
 1. Identify a specific user need or user question that you'd like to address.
 1. Create an inventory of content on your website. Navigate through the site from the home page and note the following about every piece of content. (For repeated items like blog posts, consider capturing just a sample.)
@@ -19,7 +19,7 @@
 
 <section class="method--section method--section--18f-example" markdown="1">
 
-## Example
+## Example{#ex-content-audit}
 
 - [Content debt: What it is, where to find it, and how to prevent it in the first place — 18F Blog](https://18f.gsa.gov/2016/05/19/content-debt-what-it-is-where-to-find-it-and-how-to-prevent-it-in-the-first-place/)
 
@@ -27,7 +27,7 @@
 
 <section class="method--section method--section--additional-resources" markdown="1">
 
-## Additional resources
+## Additional resources{#add-content-audit}
 
 - [Content plays: Audit your content — USDA](https://www.usda.gov/digital-strategy/content/plays#content3)
 
@@ -35,7 +35,7 @@
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government
+## Considerations for use in government{#con-content-audit}
 
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/_includes/methods/markdown/contextual-inquiry.md
+++ b/_includes/methods/markdown/contextual-inquiry.md
@@ -1,4 +1,4 @@
-## How to do it
+## How to do it{#how-contextual-inquiry}
 
 1. With permission from a supervisor and from the participant, schedule a time to watch a typical work activity and record data.
 1. While observing, ask the participant to act normally. Pretend you're a student learning how to do the job. Ask questions to help you understand what the person is doing and why.
@@ -7,7 +7,7 @@
 
 <section class="method--section method--section--18f-example" markdown="1" >
 
-## Example
+## Example{#ex-contextual-inquiry}
 
 A pair of 18F team members visited two Department of Labor/Wage Hour Division investigators as they interviewed home health care workers who were subject to unpaid overtime and other infractions. Since it was a sensitive subject, the 18F team did not question the health care workers directly, but instead asked the investigators clarifying questions in private. 18F staff also made sure that photos did not include faces.
 
@@ -15,7 +15,7 @@ A pair of 18F team members visited two Department of Labor/Wage Hour Division in
 
 <section class="method--section method--section--additional-resources" markdown="1" >
 
-## Additional resources
+## Additional resources{#add-contextual-inquiry}
 
 - <a href="https://hodigital.blog.gov.uk/2019/01/18/observational-research-5-tips-for-improving-your-approach%e2%80%af%e2%80%af/" class="usa-link">
      Observational research: 5 tips for improving your approach - GOV.UK
@@ -25,7 +25,7 @@ A pair of 18F team members visited two Department of Labor/Wage Hour Division in
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government
+## Considerations for use in government{#con-contextual-inquiry}
 
 No PRA implications, if done properly. Contextual interviews should be non-standardized, conversational, and based on observation. The PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3. See the methods for
 [Recruiting]({{ "/methods/fundamentals/recruiting/" | url }}) and [Privacy]({{ "/methods/fundamentals/privacy/" | url }}) for more tips on taking input from the public.

--- a/_includes/methods/markdown/design-hypothesis.md
+++ b/_includes/methods/markdown/design-hypothesis.md
@@ -1,4 +1,4 @@
-## How to do it
+## How to do it{#how-design-hypo}
 
 1. As a team, identify and make explicit the problem you’re trying to solve. What goals or needs aren’t being met? What measurable criteria would indicate progress toward those goals?
 
@@ -23,7 +23,7 @@
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government
+## Considerations for use in government{#con-design-hypo}
 
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/_includes/methods/markdown/design-pattern-library.md
+++ b/_includes/methods/markdown/design-pattern-library.md
@@ -1,4 +1,4 @@
-## How to do it
+## How to do it{#how-design-pat-lib}
 
 1. Start identifying common components as early as possible, ideally while you and the team are creating new design elements. These common pieces form the patterns that you will create guidelines for. Specify the components that make up each UI pattern and note possible constraints or restrictions.
 1. Describe or visualize how someone will use the pattern and how it should respond to the user. (For example: how a button renders on load, hover, and click.) Provide any data as to why it is good for the end user.
@@ -8,7 +8,7 @@
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government
+## Considerations for use in government{#con-design-pat-lib}
 
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/_includes/methods/markdown/design-principles.md
+++ b/_includes/methods/markdown/design-principles.md
@@ -1,4 +1,4 @@
-## How to do it
+## How to do it{#how-design-principals}
 
 1. Using internal documents and kickoff activities, gather terms or concepts that seem significant to project goals and organizational culture.
 1. Using existing research, list terms or concepts that seem particularly important to customers or user groups.
@@ -9,7 +9,7 @@
 
 <section class="method--section method--section--18f-example" markdown="1" >
 
-## Examples
+## Examples{#ex-design-principals}
 - 18F Design Principles Guide — [Create](https://github.com/18F/design-principles-guide/blob/18f-pages/pages/create.md), [Define](https://github.com/18F/design-principles-guide/blob/18f-pages/pages/define.md), [Usage](https://github.com/18F/design-principles-guide/blob/18f-pages/pages/usage.md)
 - [Making more consistent decisions with design principles: A new 18F guide — 18F Blog](https://18f.gsa.gov/2016/04/08/making-more-consistent-decisions-with-design-principles-a-new-18f-guide/)
 
@@ -17,7 +17,7 @@
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government
+## Considerations for use in government{#con-design-principals}
 
 No PRA implications. Generally, no information is collected from members of the public. Even when stakeholders are members of the public, the PRA explicitly exempts direct observation and non-standardized conversation (e.g., not a survey), 5 CFR 1320.3(h)3. See the methods for
 [Recruiting]({{ "/methods/fundamentals/recruiting/" | url }}) and [Privacy]({{ "/methods/fundamentals/privacy/" | url }}) for more tips on taking input from the public.

--- a/_includes/methods/markdown/design-studio.md
+++ b/_includes/methods/markdown/design-studio.md
@@ -1,4 +1,4 @@
-## How to do it
+## How to do it{#how-design-studio}
 
 1. Invite between six and 12 participants: stakeholders, users, and team members who need to build a shared understanding. Before the meeting, share applicable research, [user personas]({{ "/methods/decide/personas/" | url }}) (unless users will be present), and the design prompt for the exercise.
 1. Bring drawing materials. At the start of the meeting, review the design prompt and research you shared.
@@ -10,7 +10,7 @@
 
 <section class="method--section method--section--18f-example" markdown="1" >
 
-## Example from 18F
+## Example from 18F{#ex-design-studio}
 
 - ["User-centered design at 18F: a design studio for natural resource revenues"](https://18f.gsa.gov/2014/09/25/design-studio-onrr/) Chris Cairns , Michelle Hertzfeld , Nick Bristow.
 
@@ -18,7 +18,7 @@
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government
+## Considerations for use in government{#con-design-studio}
 
 No PRA implications. If conducted with nine or fewer members of the public, the PRA does not apply, 5 CFR 1320.5(c)4. If participants are employees, the PRA does not apply.
 </section>

--- a/_includes/methods/markdown/dot-voting.md
+++ b/_includes/methods/markdown/dot-voting.md
@@ -1,4 +1,4 @@
-## How to do it
+## How to do it{#how-dot-voting}
 
 1. Bring plenty of sticky notes and colored stickers to the meeting.
 1. Gather everyone on the product team and anyone with a stake in the product.
@@ -10,7 +10,7 @@
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government
+## Considerations for use in government{#con-dot-voting}
 
 No PRA implications: dot voting falls under "direct observation", which is explicitly exempt from the PRA, 5 CFR 1320(h)3. See the methods for [Recruiting]({{ "/methods/fundamentals/recruiting/" | url }}) and [Privacy]({{ "/methods/fundamentals/privacy/" | url }}) for more tips on taking input from the public.
 </section>

--- a/_includes/methods/markdown/five-whys.md
+++ b/_includes/methods/markdown/five-whys.md
@@ -1,4 +1,4 @@
-## How to do it
+## How to do it{#how-five-whys}
 
 Select a particular issue or problem from your user research to investigate further. This could be the most commonly occurring problem or a problem that has been prioritized by the team. 
 Ask why the problem occurred and write down an answer. Repeat this process another four times, building off of the previous response each time to drill down to a root cause. As you probe, make sure you remain sensistive to the emotional response of the interviewee. Sometimes asking why multiple times can cause the interviewee to feel frustrated or defensive if they don’t feel as if they are being heard. See example below:
@@ -21,7 +21,7 @@ After getting to a root cause, frame or reframe your problem solving approach to
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government
+## Considerations for use in government{#con-five-whys}
 
 No PRA implications. No information is collected from members of the public.
 

--- a/_includes/methods/markdown/heuristic-evaluation.md
+++ b/_includes/methods/markdown/heuristic-evaluation.md
@@ -1,4 +1,4 @@
-## How to do it
+## How to do it{#how-heuristic-eval}
 
 1. Recruit a group of three to five people familiar with evaluation methods. These people are not necessarily designers, but are familiar with common usability best practices. They are usually not users.
 1. Ask each person to individually create a list of "heuristics" or general usability best practices. Examples of heuristics from Nielsen's "10 Usability Heuristics for User Interface Design" include:
@@ -10,7 +10,7 @@
 
 <section class="method--section method--section--additional-resources" markdown="1">
 
-## Additional resources
+## Additional resources{#add-heuristic-eval}
 
 - [10 usability heuristics for user interface design — Nielsen Norman Group](https://www.nngroup.com/articles/ten-usability-heuristics/)
 - [USDA Digital strategy tools — Research — Heuristic review template](https://www.usda.gov/digital-strategy/tools)
@@ -18,7 +18,7 @@
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government
+## Considerations for use in government{#con-heuristic-eval}
 
 No PRA Implications, as heuristic evaluations usually include a small number of evaluators. If conducted with nine or fewer members of the public, the PRA does not apply, 5 CFR 1320.5(c)4. If participants are employees, the PRA does not apply. See the methods for [Recruiting]({{ "/methods/fundamentals/recruiting/" | url }}) and [Privacy]({{ "/methods/fundamentals/privacy/" | url }}) for more tips on taking input from the public.
 </section>

--- a/_includes/methods/markdown/hopes-and-fears.md
+++ b/_includes/methods/markdown/hopes-and-fears.md
@@ -1,4 +1,4 @@
-## How to do it
+## How to do it{#how-hopes-fears}
 
   1. Ahead of the session, establish what you want to elicit hopes and fears about. For example, you could ask participants to focus on the whole project or that day’s workshop.
   2. At the beginning of the session, create two columns labeled “Hopes” and “Fears” on a white board or large sticky pad.
@@ -11,7 +11,7 @@ This format can be adapted to include other categories. For example, asking part
 
 <section class="method--section method--section--18f-example" markdown="1" >
 
-## Example
+## Example{#ex-hopes-fears}
 
 - [Three small steps you can take to reboot agile in your organization — 18F Blog](https://18f.gsa.gov/2016/10/25/three-small-steps-you-can-take-to-reboot-agile-in-your-organization/)
 
@@ -20,7 +20,7 @@ This format can be adapted to include other categories. For example, asking part
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government
+## Considerations for use in government{#con-hopes-fears}
 
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/_includes/methods/markdown/interface-audit.md
+++ b/_includes/methods/markdown/interface-audit.md
@@ -1,4 +1,4 @@
-## How to do it
+## How to do it{#how-inter-audit}
 
 An interface audit can be conducted by an individual or in a group setting. Either way, the steps are as follows:
 1. Identify the website and take screenshots of all the pages you want to audit
@@ -11,14 +11,14 @@ An interface audit can be conducted by an individual or in a group setting. Eith
 
 <section class="method--section method--section--additional-resources" markdown="1">
 
-## Additional resources
+## Additional resources{#add-inter-audit}
 - [Conducting an interface inventory — Brad Frost](https://bradfrost.com/blog/post/conducting-an-interface-inventory/)
 
 </section>
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Applied in government research
+## Applied in government research{#app-inter-audit}
 
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/_includes/methods/markdown/journey-mapping.md
+++ b/_includes/methods/markdown/journey-mapping.md
@@ -1,4 +1,4 @@
-## How to do it
+## How to do it{#how-journey-mapping}
 
 1. Document the elements of the project's design context. This includes:
   - People involved and their related goals
@@ -12,14 +12,14 @@
 
 <section class="method--section method--section--additional-resources" markdown="1">
 
-## Additional resources
+## Additional resources{#add-journey-mapping}
 
 - [3-part series on the what, why, and how of journey mapping  — GSA Customer Experience Center of Excellence](https://coe.gsa.gov/2019/04/17/cx-update-9.html)
 </section>
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government
+## Considerations for use in government{#con-journey-mapping}
 
 No PRA implications. The PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3. See the methods for
 [Recruiting]({{ "/methods/fundamentals/recruiting/" | url }}) and [Privacy]({{ "/methods/fundamentals/privacy/" | url }}) for more tips on taking input from the public.

--- a/_includes/methods/markdown/kj-method.md
+++ b/_includes/methods/markdown/kj-method.md
@@ -1,4 +1,4 @@
-## How to do it
+## How to do it{#how-kj}
 
 1. Gather four or more participants for 90 minutes. Provide sticky notes and markers.
 1. Create a focused question about the project's needs and select a facilitator to run the exercise.
@@ -11,11 +11,11 @@
 
 <section class="method--section method--section--18f-example" markdown="1" >
 
-## Example from 18F
+## Example from 18F{#ex-kj}
 
 18F conducted this exercise with 20 Federal Election Commission staff members to define priorities around conflicting requests. We used this method to get data from staff (not the decision makers) about what they saw as the most pressing needs. We synthesized and presented the data back to the decision makers.
 </section>
 
-## Considerations for use in government
+## Considerations for use in government{#con-kj}
 
 At 18F, KJ participants are almost always federal employees. If there is any chance your KJ workshop could include participants who are not federal employees, consult OMB guidance on the Paperwork Reduction Act and the Privacy Act. Your agency's Office of General Counsel, and perhaps OIRA desk officers, also can ensure you are following the laws and regulations applicable to federal agencies.

--- a/_includes/methods/markdown/lean-coffee.md
+++ b/_includes/methods/markdown/lean-coffee.md
@@ -1,4 +1,4 @@
-## How to do it
+## How to do it{#how-lean-coffee}
 
 1. Give meeting participants two minutes to write what they would like to talk about on sticky notes (one idea per sticky note)
 1. Have meeting participants review the topics generated and [dot vote]({{ "/methods/discover/dot-voting/" | url }}) on the topics they are most interested in
@@ -10,7 +10,7 @@
 
 <section class="method--section method--section--18f-example" markdown="1" >
 
-## Example from 18F
+## Example from 18F{#ex-lean-coffee}
 
 At 18F, Lean coffee is often used to facilitate community of practice meetings and team meetings when the objective is to provide a forum for the meeting attendees to raise issues that are of interest to them. This method provides structure to these meetings and ensures topics are democratically selected for conversation.
 
@@ -18,7 +18,7 @@ At 18F, Lean coffee is often used to facilitate community of practice meetings a
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government
+## Considerations for use in government{#con-lean-coffee}
 
 No PRA implications. No information is collected from members of the public.
 

--- a/_includes/methods/markdown/mental-modeling.md
+++ b/_includes/methods/markdown/mental-modeling.md
@@ -1,4 +1,4 @@
-## How to do it
+## How to do it{#how-mental-model}
 
 1. Create one three-columned table per [persona]({{ "/methods/decide/personas/" | url }}). Label the columns "Past," "Present behavior," and "Future."
 1. In the middle column (Present behavior), list current user behaviors and pain points broadly related to the project, one per row.
@@ -7,7 +7,7 @@
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government
+## Considerations for use in government{#con-mental-model}
 
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/_includes/methods/markdown/multivariate-testing.md
+++ b/_includes/methods/markdown/multivariate-testing.md
@@ -1,4 +1,4 @@
-## How to do it
+## How to do it{#how-multivariate}
 
 1. Identify the call to action, content section, or feature that needs to be improved to increase conversion rates or user engagement.
 1. Develop a list of possible issues that may be hurting conversion rates or engagement. Specify in advance what you are optimizing for (possibly through [design hypothesis]({{ "/methods/decide/design-hypothesis/" | url }})).
@@ -8,7 +8,7 @@
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government
+## Considerations for use in government{#con-multivariate}
 
 No PRA implications. No one asks the users questions, so the PRA does not apply. See the methods for
 [Recruiting]({{ "/methods/fundamentals/recruiting/" | url }}) and [Privacy]({{ "/methods/fundamentals/privacy/" | url }}) for more tips on taking input from the public.

--- a/_includes/methods/markdown/personas.md
+++ b/_includes/methods/markdown/personas.md
@@ -1,4 +1,4 @@
-## How to do it
+## How to do it{#how-personas}
 
 1. Gather research from earlier activities like [contextual inquiry]({{ "/methods/discover/contextual-inquiry/" | url }}) or [stakeholder interviews]({{ "/methods/discover/stakeholder-and-user-interviews/" | url }}) in a way that's easy to review. You can create placeholder personas without research to teach user-centered thinking, but because they're effectively stereotypes, avoid using them for implementable design decisions.
 1. Create a set of user archetypes based on how you believe people will use your solution. These typically get titles (for example, "data administrators" rather than "those who submit data"). Review the archetypes with "who questions:" Who is included? Who is being overlooked? Who is deciding whom to include?
@@ -8,7 +8,7 @@
 
 <section class="method--section method--section--18f-example" markdown="1" >
 
-## Example
+## Example{#ex-personas}
 
 - [Personas for Cloud.gov — 18F GitHub](https://github.com/18F/federalist-design/wiki/Personas)
 
@@ -16,7 +16,7 @@
 
 <section class="method--section method--section--additional-resources" markdown="1">
 
-## Additional resources
+## Additional resources{#add-personas}
 
 - [Improving customer experience with digital personas — Digital.gov](https://digital.gov/2017/06/20/improving-customer-experience-with-digital-personas/)
 
@@ -24,7 +24,7 @@
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government
+## Considerations for use in government{#con-personas}
 
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/_includes/methods/markdown/privacy.md
+++ b/_includes/methods/markdown/privacy.md
@@ -1,4 +1,4 @@
-## How to do it
+## How to do it{#how-to-privacy}
 
   1. Familiarize yourself with the [Fair Information Practice Principles](https://www.fpc.gov/resources/fipps/), a set of precepts at the heart of the U.S. Privacy Act of 1974.
   1. Consult your organization's privacy office, which may include your general counsel, if you plan to substantially make use of information that could potentially identify specific individuals.
@@ -7,7 +7,7 @@
 
 <section class="method--section method--section--additional-resources" markdown="1">
 
-## Additional resources
+## Additional resources{#add-privacy}
 
 - [Doing research at TTS — TTS Handbook](https://handbook.18f.gov/research-guidelines/)
 - [Privacy — TTS Handbook](https://handbook.tts.gsa.gov/launching-software/privacy)
@@ -15,7 +15,7 @@
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government
+## Considerations for use in government{#con-privacy}
 
 The government's use of information about people is subject to a number of laws and policies, including: <a href="https://www.justice.gov/opcl/overview-privacy-act-1974-2020-edition" class="usa-link">the Privacy Act of 1974</a>, the Federal Information Security Management Act of 2002, and the eGovernment Act of 2002.
 

--- a/_includes/methods/markdown/prototyping.md
+++ b/_includes/methods/markdown/prototyping.md
@@ -1,4 +1,4 @@
-## How to do it
+## How to do it{#how-prototype}
 
 1. Create a rudimentary version of your product. It can be static or functional. Think in the same way you would about a [wireframe]({{ "/methods/make/wireframing/" | url }}): demonstrate structure and relationships among different elements, but don't worry about stylized elements.
 1. Give the prototype to the user and observe their interactions without instruction.
@@ -8,7 +8,7 @@
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government
+## Considerations for use in government{#con-prototype}
 
 No PRA implications. The PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3. See the methods for
 [Recruiting]({{ "/methods/fundamentals/recruiting/" | url }}) and [Privacy]({{ "/methods/fundamentals/privacy/" | url }}) for more tips on taking input from the public.

--- a/_includes/methods/markdown/recruiting.md
+++ b/_includes/methods/markdown/recruiting.md
@@ -1,12 +1,12 @@
-## How to do it
+## How to do it{#how-recruiting}
 
-### Seek out people who
+### Seek out people who{#seek-recruiting}
 - Are trying to use the thing you are working on right at that very moment.
 - Recently tried to use the thing you are working on.
 - Used the thing you are working on less recently.
 - Have used something like what you are working on, and are likely to use what you are working on.
 
-### Reach them through
+### Reach them through{#reach-recruiting}
 - Relevant community organizations.
 - Impromptu requests in or near the relevant environment.
 - Your personal and professional network.
@@ -15,7 +15,7 @@
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government
+## Considerations for use in government{#con-recruiting}
 
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/_includes/methods/markdown/service-blueprint.md
+++ b/_includes/methods/markdown/service-blueprint.md
@@ -1,4 +1,4 @@
-## How to do it
+## How to do it{#how-service}
 
 1. Gather information on the service through desk research and  [interviews]({{ "/methods/discover/stakeholder-and-user-interviews/" | url }}) with users, frontline staff, and support staff
 2. Create a diagram with four rows:
@@ -10,7 +10,7 @@
 
 <section class="method--section method--section--18f-example" markdown="1" >
 
-## Example from 18F
+## Example from 18F{#ex-service}
 
 18F created [this service blueprint of getting a burger]({{ "/methods/service-blueprint-example/" | url }}) as an example to illustrate what this could look like
 
@@ -18,7 +18,7 @@
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government
+## Considerations for use in government{#con-service}
 
 No PRA implications. No information is collected directly from members of the public.
 

--- a/_includes/methods/markdown/site-mapping.md
+++ b/_includes/methods/markdown/site-mapping.md
@@ -1,4 +1,4 @@
-## How to do it
+## How to do it{#how-site-mapping}
 
 1. List each page of a website or section.
 1. Take a screenshot of each page. Create a thumbnail for each screenshot.
@@ -7,7 +7,7 @@
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government
+## Considerations for use in government{#con-site-mapping}
 
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/_includes/methods/markdown/stakeholder-and-user-interviews.md
+++ b/_includes/methods/markdown/stakeholder-and-user-interviews.md
@@ -1,4 +1,4 @@
-## How to do it
+## How to do it{#how-stake}
 
   1. Create a guide for yourself of some topics you'd like to ask about, and some specific questions as a back up. Questions will often concern the individual's role, the organization, the individuals' needs, and metrics for success of the project. Consider how the interview could harm the participant, and adjust your questions to avoid those hazards. For example, might your questions trigger thoughts of painful experiences?
   1. Sit down one-on-one with the participant, or two-on-one with a note-taker or joint interviewer, in a focused environment. Introduce yourself. Explain the premise for the interview as far as you can without biasing their responses.
@@ -18,7 +18,7 @@
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government
+## Considerations for use in government{#con-stake}
 
 No PRA implications. The PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3. See the methods for [Recruiting]({{ "/methods/fundamentals/recruiting/" | url }}) and [Privacy]({{ "/methods/fundamentals/privacy/" | url }}) for more tips on taking input from the public.
 </section>

--- a/_includes/methods/markdown/stakeholder-influence-mapping.md
+++ b/_includes/methods/markdown/stakeholder-influence-mapping.md
@@ -1,4 +1,4 @@
-## How to do it
+## How to do it{#how-stake-i}
 
 1. Gather the team and, ideally, at least one crucial  stakeholder familiar with their organization and how it works from both a technical and an interpersonal point of view. 
 1. If meeting in person, you’ll need sticky notes and a whiteboard; if meeting remotely, use a virtual whiteboard or tools that support online document collaboration, ideally simultaneously.
@@ -13,7 +13,7 @@
 
 <section class="method--section method--section--18f-example" markdown="1" >
 
-## Considerations for use in government
+## Considerations for use in government{#con-stake-i}
 
 No PRA implications. No information is collected from members of the public.
 

--- a/_includes/methods/markdown/storyboarding.md
+++ b/_includes/methods/markdown/storyboarding.md
@@ -1,4 +1,4 @@
-## How to do it
+## How to do it{#how-storyboard}
 
 1. Gather any documents that describe the different use cases or [scenarios]({{ "/methods/decide/user-scenarios/" | url }}) in which users will interact with your service.
 1. Sketch scenes that visually depict a user interacting with the service, including as much context as possible. For example: Are they on the move? Where are they? What else is in their environment?
@@ -8,7 +8,7 @@
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government
+## Considerations for use in government{#con-storyboard}
 
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/_includes/methods/markdown/style-tiles.md
+++ b/_includes/methods/markdown/style-tiles.md
@@ -1,4 +1,4 @@
-## How to do it
+## How to do it{#how-style-tiles}
 
 1. Gather all the feedback and information that was provided during the initial kickoff of the project.
 1. Distill the information into different directions a solution could take. Label these directions based on what kinds of interactions and brand identity they represent.
@@ -7,7 +7,7 @@
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government
+## Considerations for use in government{#con-style-tiles}
 
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/_includes/methods/markdown/task-flow-analysis.md
+++ b/_includes/methods/markdown/task-flow-analysis.md
@@ -1,4 +1,4 @@
-## How to do it
+## How to do it{#how-task-flow}
 
 1. Based on user research, identify target users' goals that need to be analyzed.
 1. For each goal, identify common scenarios and the tasks and decisions that the user or system will perform in each scenario. Don't assume you and your stakeholders share the same understanding of the tasks. The idea is to make the flow of tasks explicit in the diagram, so that you can check your understanding by walking through the diagram with users (steps 4 & 5).
@@ -8,7 +8,7 @@
 
 <section class="method--section method--section--additional-resources" markdown="1">
 
-## Additional resources
+## Additional resources{#add-task-flow}
 
 - [Task Analysis - Usability.gov](https://www.usability.gov/how-to-and-tools/methods/task-analysis.html)
 
@@ -16,7 +16,7 @@
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government
+## Considerations for use in government{#con-task-flow}
 
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/_includes/methods/markdown/usability-testing.md
+++ b/_includes/methods/markdown/usability-testing.md
@@ -1,4 +1,4 @@
-## How to do it
+## How to do it{#how-usability}
 
 1. Pick what you’ll test. Choose something, such as a sketch, [prototype]({{ "/methods/make/prototyping/" | url }}), or even a "competitor's product" that might help users accomplish their goals.
 1. Plan the test. Align your team on the scenarios the test will focus on, which users should participate (and how you'll [recruit]({{ "/methods/fundamentals/recruiting/" | url }}) them), and which team members will moderate and observe. Prepare a [usability test script]({{ "/methods/usability-test-script/" | url }}).
@@ -9,7 +9,7 @@ main
 
 <section class="method--section method--section--18f-example" markdown="1" >
 
-## Examples from 18F
+## Examples from 18F{#ex-usability}
 
 - [Usability testing plans from 18F’s Extractive Industries Transparency Initiative project with Department of the Interior — Office of Natural Resources Revenue GitHub](https://github.com/ONRR/doi-extractives-data/blob/research/research/summary-jan2016.md)
 
@@ -17,7 +17,7 @@ main
 
 <section class="method--section method--section--additional-resources" markdown="1">
 
-## Additional resources
+## Additional resources{#add-usability}
 
 - [Introduction to remote moderated usability testing, part 1: What and why — 18F Blog](https://18f.gsa.gov/2018/11/14/introduction-to-remote-moderated-usability-testing-part-1/)
 - [Introduction to remote moderated usability testing, part 2: How — 18F Blog](https://18f.gsa.gov/2018/11/20/introduction-to-remote-moderated-usability-testing-part-2-how/)

--- a/_includes/methods/markdown/user-scenarios.md
+++ b/_includes/methods/markdown/user-scenarios.md
@@ -1,4 +1,4 @@
-## How to do it
+## How to do it{#how-user-scenario}
 
 1. Determine a few [personas]({{ "/methods/decide/personas/" | url }}) or user groups to focus on. Consider what scenario(s) might be the most critical for that user, including scenarios in which users face limited [accessibility]({{ "/accessibility/" | url }}).
 1. For each user, list out their goals, motivations, and the context/environment in which they interact with your product, service, or website.
@@ -16,7 +16,7 @@
 
 <section class="method--section method--section--additional-resources" markdown="1">
 
-## Additional resources
+## Additional resources{#add-user-scenario}
 
 - [Scenarios — Usability.gov](https://www.usability.gov/how-to-and-tools/methods/scenarios.html)
 
@@ -24,7 +24,7 @@
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government
+## Considerations for use in government{#con-user-scenario}
 
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/_includes/methods/markdown/visual-preference-testing.md
+++ b/_includes/methods/markdown/visual-preference-testing.md
@@ -1,4 +1,4 @@
-## How to do it
+## How to do it{#how-visual-preference}
 
 1. Create iterations of a [style tiles]({{ "/methods/decide/style-tiles/" | url }}) or other asset that represent directions a final visual design may follow. If branding guidelines or attributes don’t exist, establish them with stakeholders beforehand.
 1. Interview participants about their reactions.
@@ -10,7 +10,7 @@
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government
+## Considerations for use in government{#con-visual-preference}
 
 No PRA implications. The PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3. See the methods for
 [Recruiting]({{ "/methods/fundamentals/recruiting/" | url }}) and [Privacy]({{ "/methods/fundamentals/privacy/" | url }}) for more tips on taking input from the public.

--- a/_includes/methods/markdown/wireframing.md
+++ b/_includes/methods/markdown/wireframing.md
@@ -1,4 +1,4 @@
-## How to do it
+## How to do it{#how-wireframe}
 
 1. Build preliminary blueprints that show structure, placement, and hierarchy for your product. Steer clear of font choices, color, or other elements that would distract both the researcher and the reviewer. Lightweight designs are conceptually easier to reconfigure. A few helpful tools for building wireframes are OmniGraffle and Balsamiq, which purposefully keep the wireframe looking like rough sketches.
 1. Use this opportunity to start listing what UX/UI patterns you will need.
@@ -7,7 +7,7 @@
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government
+## Considerations for use in government{#con-wireframe}
 
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/_includes/methods/method.html
+++ b/_includes/methods/method.html
@@ -28,18 +28,10 @@
     <div itemprop="publisher" itemscope itemtype="http://schema.org/Organization">
     <span itemprop="name">18F</span>
     <span itemprop="logo" itemscope itemtype="https://schema.org/ImageObject">
-      <!-- TODO: handle logos when doing print design -->
-      <!--  <img class="usa-sr-only" itemprop="url" src="{{sitebase.url}}/images/18F-Logo.png" alt="18F Logo">
-       <meta itemprop="width" content="1000">
-       <meta itemprop="height" content="1000"> -->
     </span>
   </div>
   <span itemprop="author" >18F</span>
   <span itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
-    <!-- TODO: handle logos when doing print design -->
-    <!-- <img class="usa-sr-only" itemprop="url" src="{{sitebase.url}}/images/18F-Logo.png" alt="18F Logo">
-     <meta itemprop="width" content="1000">
-     <meta itemprop="height" content="1000"> -->
   </span>
   <time datetime="{{ this_method.last_modified_at | date: '%Y-%m-%d' }}" itemprop="datePublished">  {{ this_method.last_modified_at | date: '%B %d, %Y' }}</time>
 </div>

--- a/_includes/methods/method.html
+++ b/_includes/methods/method.html
@@ -22,7 +22,7 @@
     </footer>
   </div>
   <div class="method--panel method--panel--back">
-    {% renderFile this_method.content "md" %}
+    {% renderFile this_method.content, this_method, "md" %}
   </div>
   <div class="usa-sr-only">
     <div itemprop="publisher" itemscope itemtype="http://schema.org/Organization">

--- a/assets/methods/styles/_print.scss
+++ b/assets/methods/styles/_print.scss
@@ -1,0 +1,301 @@
+@media print {
+  @page{
+    size: landscape;
+    margin: 0mm;
+  }
+
+  body {
+    background: white !important;
+    color: black;
+    font-size: 12pt;
+    padding: 0;
+    -webkit-print-color-adjust: exact;
+  }
+
+  a { color: inherit; }
+
+  .wrapper {
+    margin: 0;
+    max-width: none;
+  }
+
+  .usa-alert,
+  .usa-header,
+  .usa-banner,
+  .usa-menu-btn,
+  .usa-nav,
+  .usa-navbar,
+  .card-header,
+  .category--header,
+  .method--section--18f-example,
+  .method--section--government-considerations,
+  .method--section--additional-resources,
+  .site-footer,
+  .usa-footer__return-to-top,
+  .no-print {
+    display: none;
+  }
+
+  .usa-logo { margin: 0 !important; }
+  .usa-section { padding: 0 !important; }
+
+  .usa-grid {
+    margin-top: 1em;
+  }
+
+  .banner{
+    max-width: 1040px;
+    margin: 0 auto;
+  }
+
+  .usa-logo img{
+    display: none;
+  }
+
+  .usa-logo-text{ font-size: 14pt; }
+
+  // Homepage print styles
+
+  .layout--methods .usa-navbar{ margin-bottom: 0.5in; }
+
+  .layout--methods .usa-logo img{
+    width: 0.67in;
+    top: 0.033in;
+  }
+  .layout--methods .usa-logo-text{ font-size: 20pt; }
+
+  .layout--methods .intro-header,
+  .layout--methods .category .a-see-all,
+  .layout--methods .category .methods-listing h2 { display: none; }
+
+
+  .layout--methods .category .methods-listing {
+    border: none;
+    -webkit-column-count: 2;
+    padding: 0;
+    max-width: 53rem;
+  }
+
+  .layout--methods .category .category--title {
+    font-size: 16pt;
+    padding: 0;
+    border-bottom-width: 2px;
+  }
+
+  .layout--methods .category .usa-width-two-thirds{
+    border-top-width: 4px;
+  }
+
+  .layout--methods .category .category--subtitle {
+    font-size: 13pt;
+    font-weight: inherit;
+    margin-top: 0.4em;
+    margin-bottom: 0.4em;
+  }
+
+  // Method (individual, category) print styles
+
+  .usa-grid {
+    padding: 0 !important;
+    max-width: none !important;
+  }
+
+  .category {
+    background: white !important;
+    page-break-after: always;
+  }
+
+  .method {
+    border: 1px dashed #ccc;
+    border-radius: 0;
+    box-shadow: none;
+    height: 6in;
+    position: relative;
+    margin: 0;
+    left: 1.5in;
+    top: 1.25in;
+    page-break-after: always;
+    width: 8in;
+  }
+
+  .site-header::before,
+  .site-header::after,
+  .category--header::before,
+  .category--header::after,
+  .method::before,
+  .method::after {
+    font-family: 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif;
+    font-size: 10pt;
+    font-weight: bold;
+    height: .4in;
+    line-height: 1.3;
+    position: absolute;
+    text-align: center;
+    text-transform: uppercase;
+    width: .4in;
+  }
+
+  // Fold icon
+  .method::before {
+    bottom: 100%;
+    content: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDE5LjIuMSwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCA1Ny4zIDY0LjciIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDU3LjMgNjQuNzsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgoJLnN0MHtmaWxsOm5vbmU7c3Ryb2tlOiMwMDAwMDA7c3Ryb2tlLXdpZHRoOjI7c3Ryb2tlLWxpbmVqb2luOnJvdW5kO3N0cm9rZS1taXRlcmxpbWl0OjEwO30KCS5zdDF7ZW5hYmxlLWJhY2tncm91bmQ6bmV3ICAgIDt9Cjwvc3R5bGU+CjxwYXRoIGQ9Ik01NC4xLDIuOWMtMC4yLTAuMS0wLjUtMC4yLTAuNy0wLjJMMS45LDMuOUwyLDUuM2gwLjF2NTMuOWMwLDAuNCwwLjQsMC42LDAuOSwwLjdsNDEuOSwzSDQ1YzAuMiwwLDAuNS0wLjEsMC43LTAuMgoJYzAuMi0wLjEsMC4zLTAuNCwwLjMtMC41di01LjZsNy42LTAuNWMwLjUsMCwwLjktMC40LDAuOS0wLjdWMy41QzU0LjQsMy4yLDU0LjMsMy4xLDU0LjEsMi45eiBNNDMuOSw2MS41TDQsNTguNlY1LjVsMzkuOSwyLjlWNjEuNQoJeiBNNTIuNCw1NC43bC02LjUsMC40VjcuN0M0NS45LDcuMyw0NS41LDcsNDUsN0wxNy4xLDVsMzUuMy0wLjhMNTIuNCw1NC43TDUyLjQsNTQuN3oiLz4KPC9zdmc+) 'Fold';
+    left: 50%;
+    margin-bottom: .5in;
+    margin-left: -.2in;
+  }
+
+  // Scissors icon
+  .method::after {
+    content: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDE5LjIuMSwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCA4Mi41IDgyLjMzIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA4Mi41IDgyLjMzOyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+CjxzdHlsZSB0eXBlPSJ0ZXh0L2NzcyI+Cgkuc3Qwe2ZpbGw6bm9uZTtzdHJva2U6IzAwMDAwMDtzdHJva2UtbGluZWNhcDpyb3VuZDtzdHJva2UtbGluZWpvaW46cm91bmQ7c3Ryb2tlLW1pdGVybGltaXQ6MTA7fQo8L3N0eWxlPgo8cGF0aCBjbGFzcz0ic3QwIiBkPSJNMzEuMTIsNjEuOTFsLTEuMDItMi40N2wtNS41MiwyLjI4bDYuMDksMTQuNjljMS42OSw0LjA2LDYuMzUsNS45OCwxMC40MSw0LjN2MAoJYzQuMDYtMS42OCw1Ljk5LTYuMzMsNC4zMS0xMC4zOWwwLDBjLTAuODQtMi4wMy0yLjQyLTMuNTItNC4zMS00LjMxTDMxLjEyLDYxLjkxeiIvPgo8cGF0aCBjbGFzcz0ic3QwIiBkPSJNNDEuNzIsNzEuODZjLTAuNDItMS4wMi0xLjIxLTEuNzYtMi4xNi0yLjE1bC04Ljg4LTMuNjhsMy42OCw4Ljg2YzAuODUsMi4wMywzLjE3LDIuOTksNS4yLDIuMTVsMCwwCglDNDEuNiw3Ni4yMiw0Mi41Niw3My44OSw0MS43Miw3MS44Nkw0MS43Miw3MS44NnoiLz4KPHBhdGggY2xhc3M9InN0MCIgZD0iTTE5LjI2LDQ2LjI5bC03LjYyLTE4LjM3TDE5LjI2LDQ2LjI5eiIvPgo8cGF0aCBjbGFzcz0ic3QwIiBkPSJNMjguMjYsNjAuMjFMMTMuMDMsMjMuNDhjLTIuNjYsNi40Mi0yLjg3LDEzLjg2LDAsMjAuNzlsNC44MywxMS42NGw1Ljk3LDMuOTlsMC43NiwxLjgzTDI4LjI2LDYwLjIxeiIvPgo8cGF0aCBjbGFzcz0ic3QwIiBkPSJNMTUuODcsNjEuOTFsMS4wMi0yLjQ3bDUuNTIsMi4yOGwtNi4wOSwxNC42OWMtMS42OCw0LjA2LTYuMzQsNS45OC0xMC40LDQuM3YwCgljLTQuMDYtMS42OC01Ljk5LTYuMzMtNC4zMS0xMC4zOWwwLDBjMC44NC0yLjAzLDIuNDMtMy41Miw0LjMxLTQuMzFMMTUuODcsNjEuOTF6Ii8+CjxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik01LjI4LDcxLjg2YzAuNDItMS4wMiwxLjIxLTEuNzYsMi4xNi0yLjE1bDguODgtMy42OGwtMy42OCw4Ljg2Yy0wLjg0LDIuMDMtMy4xNywyLjk5LTUuMiwyLjE1bDAsMAoJQzUuNDEsNzYuMjIsNC40NCw3My44OSw1LjI4LDcxLjg2TDUuMjgsNzEuODZ6Ii8+Cjxwb2x5Z29uIGNsYXNzPSJzdDAiIHBvaW50cz0iMTkuOTQsNTcuMyAxOC43NCw2MC4yMSAyMi40MSw2MS43MyAyMy4xNyw1OS45IDIzLjUsNTkuNjggIi8+Cjxwb2x5Z29uIGNsYXNzPSJzdDAiIHBvaW50cz0iMjkuNjMsNTQuNzEgMjkuNjMsMzMuOTMgMjMuNDksNDguNzMgMjcuMDUsNTcuMyAyOS4xMyw1NS45MSAiLz4KPHBhdGggY2xhc3M9InN0MCIgZD0iTTgxLDEwLjY3djQuNjdWMTAuNjd6Ii8+CjxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik04MSwyMC4wMXY0LjY3VjIwLjAxeiIvPgo8cGF0aCBjbGFzcz0ic3QwIiBkPSJNODEsMjkuMzV2NC42N1YyOS4zNXoiLz4KPHBhdGggY2xhc3M9InN0MCIgZD0iTTgxLDM4LjY5djQuNjdWMzguNjl6Ii8+CjxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik04MSw0OC4wNHY0LjY3VjQ4LjA0eiIvPgo8cGF0aCBjbGFzcz0ic3QwIiBkPSJNODEsNTcuMzh2NC42N1Y1Ny4zOHoiLz4KPHBhdGggY2xhc3M9InN0MCIgZD0iTTI5LjYzLDEwLjY3djQuNjdWMTAuNjd6Ii8+CjxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik0yOS42MywyMC4wMXY0LjY3VjIwLjAxeiIvPgo8cGF0aCBjbGFzcz0ic3QwIiBkPSJNMjkuNjMsMjkuMzV2NC42N1YyOS4zNXoiLz4KPHBhdGggY2xhc3M9InN0MCIgZD0iTTM4Ljk3LDEuMzNoNC42N0gzOC45N3oiLz4KPHBhdGggY2xhc3M9InN0MCIgZD0iTTQ4LjMxLDEuMzNoNC42N0g0OC4zMXoiLz4KPHBhdGggY2xhc3M9InN0MCIgZD0iTTU3LjY1LDEuMzNoNC42N0g1Ny42NXoiLz4KPHBhdGggY2xhc3M9InN0MCIgZD0iTTY2Ljk5LDEuMzNoNC42N0g2Ni45OXoiLz4KPHBvbHlnb24gY2xhc3M9InN0MCIgcG9pbnRzPSIyOS42Myw2IDI5LjYzLDEuMzMgMzQuMywxLjMzIDI5LjYzLDEuMzMgIi8+Cjxwb2x5Z29uIGNsYXNzPSJzdDAiIHBvaW50cz0iODEsNiA4MSwxLjMzIDgxLDEuMzMgNzYuMzMsMS4zMyA4MSwxLjMzIDgxLDEuMzMgIi8+Cjxwb2x5Z29uIGNsYXNzPSJzdDAiIHBvaW50cz0iODEsNjYuNzEgODEsNzEuMzkgODEsNzEuMzkgNzYuMzMsNzEuMzkgODEsNzEuMzkgODEsNzEuMzkgIi8+CjxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik02Ni45OSw3MS4zOWg0LjY3SDY2Ljk5eiIvPgo8cGF0aCBjbGFzcz0ic3QwIiBkPSJNNTcuNjUsNzEuMzloNC42N0g1Ny42NXoiLz4KPHBhdGggY2xhc3M9InN0MCIgZD0iTTQ4LjMxLDcxLjM5aDQuNjdINDguMzF6Ii8+Cjwvc3ZnPg==) 'Cut';
+    margin-right: .33in;
+    margin-top: -.275in;
+    right: 100%;
+    top: 50%;
+  }
+
+
+  .method .method--panel--front,
+  .method .method--panel--back {
+    box-sizing: border-box;
+    float: left;
+    height: 6.5in;
+    overflow: hidden;
+    padding: .25in .3in;
+    position: relative;
+    width: 50%;
+  }
+
+  .method .method--panel--front footer {
+    bottom: 0;
+    display: table;
+    left: 0;
+    padding: 0 30px 20px;
+    position: absolute;
+    width: 100%;
+  }
+
+  .method .method--panel--back {
+    background: none;
+    border-left: 1px solid #f1f1f1;
+    float: right;
+    font-size: 9pt;
+  }
+
+  .method {
+    background: white;
+    border-radius: 0;
+    clear: both;
+    position: relative;
+  }
+
+  .method:target {
+    border-color: inherit;
+    box-shadow: none;
+  }
+
+  .method--title {
+    font-size: 23pt !important;
+    margin-top: 10px !important;
+    padding-top: 15px !important;
+    a {
+      text-decoration: none;
+    }
+  }
+  .method h1 {
+    font-size: 14pt;
+  }
+  .method h2 {
+    font-size: 14pt;
+  }
+
+  .method .method--panel--front p {
+    font-size: 10.5pt;
+    font-weight: normal;
+    line-height: 1.3;
+  }
+
+  .method .method--panel--back h1,
+  .method .method--panel--back h2 {
+    font-size: 11pt;
+  }
+
+  .method .method--panel--back h3 {
+    font-size: 10pt;
+    font-weight: 400;
+    margin-bottom: .6rem;
+    margin-top: 0;
+  }
+
+  .method .method--panel--back {
+    font-size: 9pt;
+  }
+
+  .method .method--panel--back {
+    :first-child {
+      margin-top: .6em;
+    }
+  }
+
+  .method .method--panel--back::after {
+    border-top: 1px solid #f1f1f1;
+    bottom: .1in;
+    bottom: .3125in;
+    content: 'Learn more: methods.18f.gov';
+    display: block;
+    font-size: 8pt;
+    font-style: italic;
+    left: .25in;
+    padding-top: .0625in;
+    position: absolute;
+    right: .25in;
+  }
+  .method .method--section--category {
+    min-width: 0;
+    padding-right: .5in;
+  }
+
+
+
+  .layout--example-usability-test-script .banner,
+  .layout--example-interview-debrief-worksheet .banner,
+  .layout--interview-checklist .banner{
+    display: none;
+  }
+
+  .layout--example-usability-test-script h1,
+  .layout--example-usability-test-script p,
+  .layout--example-interview-debrief-worksheet h1,
+  .layout--example-interview-debrief-worksheet p{
+    max-width: none;
+  }
+
+  .layout--example-usability-test-script h1,
+  .layout--example-user-interview-script h1,
+  .layout--interview-checklist h1,
+  .layout--example-interview-debrief-worksheet h1{
+      font-size: 20pt;
+      margin-top: 0 !important;
+  }
+
+  .layout--interview-checklist h2,
+  .layout--example-usability-test-script h2,
+  .layout--example-interview-debrief-worksheet h2,
+  .layout--example-user-interview-script h2{
+    font-size: 17pt;
+  }
+
+  .layout--interview-checklist h3,
+  .layout--example-usability-test-script h3,
+  .layout--example-interview-debrief-worksheet h3,
+  .layout--example-user-interview-script h3{
+    font-size: 14pt;
+  }
+
+  .layout--interview-checklist .page h1#interview-checklist{ margin-top: 0 ; }
+
+  .layout--interview-checklist .page p,
+  .layout--interview-checklist .page li {
+    line-height: 1.4em;
+  }
+
+}

--- a/assets/methods/styles/methods-styles.scss
+++ b/assets/methods/styles/methods-styles.scss
@@ -21,3 +21,4 @@ Custom styling for methods guide only
 @forward "service-blueprint";
 @forward "usability-test-script";
 @forward "interview-script";
+@forward "print";

--- a/content/methods/print.md
+++ b/content/methods/print.md
@@ -1,6 +1,6 @@
 ---
 title: Print - Methods
 permalink: /methods/print/
-layout: layouts/page
+layout: layouts/methods-print
 tags: methods
 ---


### PR DESCRIPTION
## Changes proposed in this pull request:

Adds print styling for all print buttons:

1. print all cards
2. print all [category] cards
3. print this card

All changes in `_includes/methods/markdown` are to make pa11y tests pass by giving all headers unique id's. Markdown will render each header with an id to use as an anchor link, using the title of the header as default. Since we have many "how to do it" and "considerations" etc. headers on multi-card pages, this was making tests fail. 

Using the `markdownItAttrs` package, we can provide a custom id to markdown headers by doing `## Header Name{#your-id}` in the markdown. The id's don't need to be semantic or standardized—they just need to be unique to any page their on. So I used a version of the method title for each id. 

I couldn't figure out a way to pass variables (like method name) to this feature. Otherwise, that would've been a more dynamic way to do this. 

closes #235 

## security considerations

None
