### PR TITLE
Port page descriptions from old site

### DIFF
--- a/content/methods/decide/affinity-mapping.md
+++ b/content/methods/decide/affinity-mapping.md
@@ -1,5 +1,6 @@
 ---
 title: Affinity mapping
+description: A way of finding themes in collections of ideas, quotes, or observations.
 permalink: /methods/decide/affinity-mapping/
 redirect_from:
   - affinity-mapping/

--- a/content/methods/decide/comparative-analysis.md
+++ b/content/methods/decide/comparative-analysis.md
@@ -1,5 +1,6 @@
 ---
 title: Comparative analysis
+description: A detailed review of existing experiences provided either by direct competitors or by related agencies or services.
 permalink: /methods/decide/comparative-analysis/
 redirect_from:
   - /comparative-analysis/

--- a/content/methods/decide/content-audit.md
+++ b/content/methods/decide/content-audit.md
@@ -1,5 +1,6 @@
 ---
 title: Content audit
+description: A listing and analysis of all the content on an existing website (including pages, files, videos, audio or other data) that your users might reasonably encounter.
 permalink: /methods/decide/content-audit/
 redirect_from:
   - content-audit/

--- a/content/methods/decide/design-hypothesis.md
+++ b/content/methods/decide/design-hypothesis.md
@@ -1,5 +1,6 @@
 ---
 title: Design hypothesis
+description: A listing and analysis of all the content on an existing website (including pages, files, videos, audio or other data) that your users might reasonably encounter.
 permalink: /methods/decide/design-hypothesis/
 redirect_from:
   - design-hypothesis/

--- a/content/methods/decide/design-principles.md
+++ b/content/methods/decide/design-principles.md
@@ -1,5 +1,6 @@
 ---
 title: Design principles
+description: Written statements, generally in the form of imperatives like "Earn people's trust," that serve as guiding lights during decision-making.
 permalink: /methods/decide/design-principles/
 redirect_from:
   - design-principles/

--- a/content/methods/decide/interface-audit.md
+++ b/content/methods/decide/interface-audit.md
@@ -1,5 +1,6 @@
 ---
 title: Interface audit
+description: A listing and analysis of all the components, design patterns, and interface features of an existing website (including typography, color, graphics/illustration/icons).
 permalink: /methods/decide/interface-audit/
 redirect_from:
   - interface-audit/

--- a/content/methods/decide/journey-mapping.md
+++ b/content/methods/decide/journey-mapping.md
@@ -1,5 +1,6 @@
 ---
 title: Journey mapping
+description: A visualization of the major interactions shaping a user's experience of a product or service.
 permalink: /methods/decide/journey-mapping/
 redirect_from:
   - journey-mapping/

--- a/content/methods/decide/mental-modeling.md
+++ b/content/methods/decide/mental-modeling.md
@@ -1,5 +1,6 @@
 ---
 title: Mental modeling
+description: A simple reference model that correlates existing and potential interfaces with user behaviors.
 permalink: /methods/decide/mental-modeling/
 redirect_from:
   - mental-modeling/

--- a/content/methods/decide/personas.md
+++ b/content/methods/decide/personas.md
@@ -1,5 +1,6 @@
 ---
 title: Personas
+description: User archetypes based on conversations with real people.
 permalink: /methods/decide/personas/
 redirect_from:
   - personas/

--- a/content/methods/decide/service-blueprint.md
+++ b/content/methods/decide/service-blueprint.md
@@ -1,5 +1,6 @@
 ---
 title: Service blueprint
+description: A visual representation of the start-to-finish experience of both using and supporting the delivery of a service, including staff interactions and user experience.
 permalink: /methods/decide/service-blueprint/
 redirect_from:
   - service-blueprint/

--- a/content/methods/decide/site-mapping.md
+++ b/content/methods/decide/site-mapping.md
@@ -1,5 +1,6 @@
 ---
 title: Site mapping
+description: A comprehensive rendering of how a website's pages relate to one another.
 permalink: /methods/decide/site-mapping/
 redirect_from:
   - site-mapping/

--- a/content/methods/decide/storyboarding.md
+++ b/content/methods/decide/storyboarding.md
@@ -1,5 +1,6 @@
 ---
 title: Storyboarding
+description: A wide-spanning set of semi-structured interviews with anyone who has an interest in a project's success, including users.
 permalink: /methods/decide/storyboarding/
 redirect_from:
   - storyboarding/

--- a/content/methods/decide/style-tiles.md
+++ b/content/methods/decide/style-tiles.md
@@ -1,5 +1,6 @@
 ---
 title: Style tiles
+description: A design document that contains various fonts, colors, and UI elements that communicate the visual brand direction for a website or application.
 permalink: /methods/decide/style-tiles/
 redirect_from:
   - style-tiles/

--- a/content/methods/decide/task-flow-analysis.md
+++ b/content/methods/decide/task-flow-analysis.md
@@ -1,5 +1,6 @@
 ---
 title: Task flow analysis
+description: A step-by-step analysis of how a user will interact with a system in order to reach a goal. This analysis is documented in a diagram that traces a user's possible paths through sequences of tasks and decision points in pursuit of their goal. The tasks and decision points should represent steps taken by the user, as well as steps taken by the system.
 permalink: /methods/decide/task-flow-analysis/
 redirect_from:
   - task-flow-analysis/

--- a/content/methods/decide/user-scenarios.md
+++ b/content/methods/decide/user-scenarios.md
@@ -1,5 +1,6 @@
 ---
 title: User scenarios
+description: A method for telling a conceptual story about a user's interaction with your website, focusing on the what, how, and why.
 permalink: /methods/decide/user-scenarios/
 redirect_from:
   - user-scenarios/

--- a/content/methods/discover/cognitive-walkthrough.md
+++ b/content/methods/discover/cognitive-walkthrough.md
@@ -1,5 +1,6 @@
 ---
 title: Cognitive walkthrough
+description: An evaluation method in which people work through a set of representative tasks and ask questions about the task as they go.
 permalink: /methods/discover/cognitive-walkthrough/
 layout: layouts/method-card
 tags: methods

--- a/content/methods/discover/contextual-inquiry.md
+++ b/content/methods/discover/contextual-inquiry.md
@@ -1,5 +1,6 @@
 ---
 title: Contextual inquiry
+description: The product team unobtrusively observes participants at work, with their permission, then asks questions.
 permalink: /methods/discover/contextual-inquiry/
 redirect_from:
   - contextual-inquiry/

--- a/content/methods/discover/design-studio.md
+++ b/content/methods/discover/design-studio.md
@@ -1,5 +1,6 @@
 ---
 title: Design studio
+description: An illustration-based way to facilitate communication (and brainstorming) between a project team and stakeholders.
 permalink: /methods/discover/design-studio/
 layout: layouts/method-card
 tags: methods

--- a/content/methods/discover/dot-voting.md
+++ b/content/methods/discover/dot-voting.md
@@ -1,5 +1,6 @@
 ---
 title: Dot voting
+description: A simple voting exercise to identify a group's collective priorities.
 permalink: /methods/discover/dot-voting/
 redirect_from:
   - discover/feature-dot-voting/

--- a/content/methods/discover/five-whys.md
+++ b/content/methods/discover/five-whys.md
@@ -1,5 +1,6 @@
 ---
 title: Five whys
+description: An iterative process for identifying the root cause of a problem by posing the question "Why?" at least five times to help separate symptoms from causes.
 permalink: /methods/discover/five-whys/
 redirect_from:
   - five-whys/

--- a/content/methods/discover/heuristic-evaluation.md
+++ b/content/methods/discover/heuristic-evaluation.md
@@ -1,5 +1,6 @@
 ---
 title: Heuristic evaluation
+description: A quick way to find common, large usability problems on a website.
 permalink: /methods/discover/heuristic-evaluation/
 redirect_from:
   - discover/heuristic-analysis/

--- a/content/methods/discover/hopes-and-fears.md
+++ b/content/methods/discover/hopes-and-fears.md
@@ -1,5 +1,6 @@
 ---
 title: Hopes and fears
+description: An exercise that quickly surfaces a group’s hopes and fears for the future
 permalink: /methods/discover/hopes-and-fears/
 redirect_from:
   - hopes-and-fears/

--- a/content/methods/discover/kj-method.md
+++ b/content/methods/discover/kj-method.md
@@ -1,5 +1,6 @@
 ---
 title: KJ method
+description: A facilitated exercise in which participants list their individual priorities onto cards, collect them as a group, organize them by relationship, and establish group priorities through individual voting.
 permalink: /methods/discover/kj-method/
 redirect_from:
   - kj-method/

--- a/content/methods/discover/lean-coffee.md
+++ b/content/methods/discover/lean-coffee.md
@@ -1,5 +1,6 @@
 ---
 title: Lean coffee
+description: A format for running a meeting without a predefined agenda
 permalink: /methods/discover/lean-coffee/
 redirect_from:
   - lean-coffee/

--- a/content/methods/discover/stakeholder-and-user-interviews.md
+++ b/content/methods/discover/stakeholder-and-user-interviews.md
@@ -1,5 +1,6 @@
 ---
 title: Stakeholder and user interviews
+description: A wide-spanning set of semi-structured interviews with living experts who have an interest in a project's success, including stakeholders and users.
 permalink: /methods/discover/stakeholder-and-user-interviews/
 redirect_from:
   - stakeholder-and-user-interviews/

--- a/content/methods/discover/stakeholder-influence-mapping.md
+++ b/content/methods/discover/stakeholder-influence-mapping.md
@@ -1,5 +1,6 @@
 ---
 title: Stakeholder influence mapping
+description: A visual representation of stakeholders — the people who are involved — and their potential influence and impact on a project or service system, in comparison to one another.
 permalink: /methods/discover/stakeholder-influence-mapping/
 redirect_from:
   - stakeholder-influence-mapping/

--- a/content/methods/interview-checklist.md
+++ b/content/methods/interview-checklist.md
@@ -1,5 +1,6 @@
 ---
 title: Interview checklist
+description: Helpful reminders for moderating interviews
 permalink: /methods/interview-checklist/
 layout: layouts/page
 tags: methods

--- a/content/methods/make/design-pattern-library.md
+++ b/content/methods/make/design-pattern-library.md
@@ -1,5 +1,6 @@
 ---
 title: Design pattern library
+description: A collection of user interface elements (for example colors, icons, and buttons) used frequently across a website or service, consisting of the base patterns and helpful information about how to use them.
 permalink: /methods/make/design-pattern-library/
 redirect_from:
   - design-pattern-library/

--- a/content/methods/make/prototyping.md
+++ b/content/methods/make/prototyping.md
@@ -1,5 +1,6 @@
 ---
 title: Prototyping
+description: A rudimentary version, either static or functional, of something that exhibits realistic form and function.
 permalink: /methods/make/prototyping/
 redirect_from:
   - prototyping/

--- a/content/methods/make/wireframing.md
+++ b/content/methods/make/wireframing.md
@@ -1,5 +1,6 @@
 ---
 title: Wireframing
+description: A simple visual representation of a product or service interface.
 permalink: /methods/make/wireframing/
 redirect_from:
   - wireframing/

--- a/content/methods/validate/card-sorting.md
+++ b/content/methods/validate/card-sorting.md
@@ -1,5 +1,6 @@
 ---
 title: Card sorting
+description: A listing and analysis of all the content on an existing website (including pages, files, videos, audio or other data) that your users might reasonably encounter.
 permalink: /methods/validate/card-sorting/
 redirect_from:
   - card-sorting/

--- a/content/methods/validate/multivariate-testing.md
+++ b/content/methods/validate/multivariate-testing.md
@@ -1,5 +1,6 @@
 ---
 title: Multivariate testing
+description: A test of variations to multiple sections or features of a page to see which combination of variants has the greatest effect. Different from an A/B test, which tests variation to just one section or feature.
 permalink: /methods/validate/multivariate-testing/
 redirect_from:
   - multivariate-testing/

--- a/content/methods/validate/usability-testing.md
+++ b/content/methods/validate/usability-testing.md
@@ -1,5 +1,6 @@
 ---
 title: Usability testing
+description: Observing users as they attempt to use a product or service while thinking out loud.
 permalink: /methods/validate/usability-testing/
 redirect_from:
   - usability-testing/

--- a/content/methods/validate/visual-preference-testing.md
+++ b/content/methods/validate/visual-preference-testing.md
@@ -1,5 +1,6 @@
 ---
 title: Visual preference testing
+description: A method that allows potential users to review and provide feedback on a solution's visual direction.
 permalink: /methods/validate/visual-preference-testing/
 redirect_from:
   - visual-preference-testing/


### PR DESCRIPTION
## Changes proposed in this pull request:

Since page descriptions are used in meta tags, we should port over the descriptions from the old site.

Relates to #352 

## security considerations

None / content change only
