### PR TITLE
Apply derisking guide checkbox style throughout guides

### DIFF
--- a/assets/_common/styles/custom-styles.scss
+++ b/assets/_common/styles/custom-styles.scss
@@ -180,13 +180,15 @@ h2.heading-md {
 }
 
 .guide-checklist + ul,
-.guide-checklist + ul ul {
+.guide-checklist + ul ul,
+.guide-checklist--single + ul {
   list-style: none;
   margin-left: 0;
   padding-left: units(1);
 }
 
-.guide-checklist + ul li {
+.guide-checklist + ul li,
+.guide-checklist--single + ul li {
   padding-left: $bullet-spacing;
   text-indent: (-1 * $bullet-spacing);
 

--- a/content/ux-guide/resources/interview-checklist.md
+++ b/content/ux-guide/resources/interview-checklist.md
@@ -37,88 +37,88 @@ Note that the permalink here does not include /resources/ so there's no indicati
 ## Pre-interview preparation
 **Set aside 10 minutes** before the interview begins to help your team intentionally transition to an inquiring mindset, to clarify with your colleagues their respective roles, to check any technologies on which the interview will rely, etc.
 
-### Make sure to
-- [ ] Remind your team of the purpose of the interview
-- [ ] Establish clear roles for anyone who will join (for example, moderators, observers, notetakers, etc.).
-- [ ] Confirm with teammates, especially remote ones, how they might ask questions during the interview (for example, in a Slack thread)
-- [ ] Do a tech check: confirm that screen sharing, recording, etc. works
-- [ ] Check receipt of a signed participant agreement ([example]({{ '/ux-guide/participant-agreement/' | url }}))
-- [ ] Double-check any links, files, etc. that participants will need to evaluate (i.e., ensure that your concept, wireframes, or prototypes are available for testing)
+### Make sure to {.guide-checklist}
+- Remind your team of the purpose of the interview
+- Establish clear roles for anyone who will join (for example, moderators, observers, notetakers, etc.).
+- Confirm with teammates, especially remote ones, how they might ask questions during the interview (for example, in a Slack thread)
+- Do a tech check: confirm that screen sharing, recording, etc. works
+- Check receipt of a signed participant agreement ([example]({{ '/ux-guide/participant-agreement/' | url }}))
+- Double-check any links, files, etc. that participants will need to evaluate (i.e., ensure that your concept, wireframes, or prototypes are available for testing)
 
 
 ## Introductions
 **Spend 5 minutes** at the beginning of the interview to clarify with the participant the parameters of the interview, and to give them a chance to ask any logistics-related questions.
 
-### Make sure to
-- [ ] Thank the participant for their time
-- [ ] Introduce yourself, and anyone who is joining you
-- [ ] Explain the purpose of your research
-- [ ] Provide an overview of the shape of the interview, including any required logistics (for example, screen sharing)
-- [ ] Confirm the expected length of the interview
-- [ ] Confirm receipt of a signed participant agreement ([example]({{ '/ux-guide/participant-agreement/' | url }}))
-- [ ] Explain
-  - [ ] How you’ll take notes (for example, video recording).
-  - [ ] How you’ll use any notes you take (for example, unattributed quotes)
-- [ ] Ask the participant if they have questions at this time
-- [ ] If the participant consents, turn on the recorder
+### Make sure to {.guide-checklist}
+- Thank the participant for their time
+- Introduce yourself, and anyone who is joining you
+- Explain the purpose of your research
+- Provide an overview of the shape of the interview, including any required logistics (for example, screen sharing)
+- Confirm the expected length of the interview
+- Confirm receipt of a signed participant agreement ([example]({{ '/ux-guide/participant-agreement/' | url }}))
+- Explain
+  - How you’ll take notes (for example, video recording).
+  - How you’ll use any notes you take (for example, unattributed quotes)
+- Ask the participant if they have questions at this time
+- If the participant consents, turn on the recorder
 
 
 ## Warm-up / icebreaker
 **Spend 5-10 minutes** establishing the cadence for the interview as a conversation rather than a stilted back and forth. Help the participant feel comfortable, and focus on gaining important context for the body of the interview.
 
-### Make sure to
-- [ ] Be polite; you’re a guest in the participant’s world
-- [ ] Give the participant your full attention (You can signal this by making eye contact, asking follow up questions, etc. Be aware that taking notes, especially on a laptop, can distract from the conversation itself)
-- [ ] Ask open-ended questions that will give you relevant information and help you form a better understanding of who this person is
-- [ ] Understand the degree to which this person is comfortable talking about themselves and their work, and at what speed. Be mindful and respectful of anything the the participant is uncomfortable talking about
-- [ ] Give the participant time to respond; don’t be afraid of awkward pauses
-- [ ] Ask for a “tour”: note any organizations, tools, rituals, or processes that affect your participant’s perspective
-- [ ] Start broad (“So to start, could you tell us how you got into this line of work?” or “What’s a day in your work-life like?”), and then slowly direct the interview toward any planned activities (“Could you share your screen and show me how you do that?”) or topic-specific questions (“How often do you file TPS reports?”)
+### Make sure to {.guide-checklist}
+- Be polite; you’re a guest in the participant’s world
+- Give the participant your full attention (You can signal this by making eye contact, asking follow up questions, etc. Be aware that taking notes, especially on a laptop, can distract from the conversation itself)
+- Ask open-ended questions that will give you relevant information and help you form a better understanding of who this person is
+- Understand the degree to which this person is comfortable talking about themselves and their work, and at what speed. Be mindful and respectful of anything the the participant is uncomfortable talking about
+- Give the participant time to respond; don’t be afraid of awkward pauses
+- Ask for a “tour”: note any organizations, tools, rituals, or processes that affect your participant’s perspective
+- Start broad (“So to start, could you tell us how you got into this line of work?” or “What’s a day in your work-life like?”), and then slowly direct the interview toward any planned activities (“Could you share your screen and show me how you do that?”) or topic-specific questions (“How often do you file TPS reports?”)
 
 
 ## Activities or topic-specific questions
 **Spend 25 minutes** exploring the topics or leading the participant through the activities (for example, screen sharing) the research was designed around.
 
-### Make sure to
-- [ ] Know what you want to learn
-- [ ] Demonstrate genuine curiosity
-- [ ] Let the conversation flow naturally, and try and get the participant to tell stories — yes, stories — related to the things you’re studying
-- [ ] Default to open-ended questions such as “Tell me about a time… ”, “Can you explain…”, “Why do you think…”
-- [ ] Ask clarifying questions or ask your interviewee to repeat themselves if you missed something
-- [ ] Use a diverse array of question types, such as context-gathering questions (asking about sequences of events, relationships, etc.), clarification questions, and comparison/contrasting questions
-- [ ] Use transition phrases to help participants understand when you are moving between parts of the interview (“let’s go back to something you said before”)
-- [ ] Test your own assumptions and understandings without asking leading questions. Ask “how” and “why” multiple times, and give the participant sufficient time to think about their answers
-- [ ] Note the exact words and phrases people use. Don’t correct them, even their pronunciation, if you think they’re wrong
-- [ ] Look people in the eye and give positive affirmations. Lean forward. Say things like “Wow,” or “Oh, interesting!” (when those reactions genuinely occur to you, of course)
-- [ ] If you ask the participant to share their screen
-  - [ ] Caution them to close anything they don't want recorded beforehand
-  - [ ] Assure them that there are no wrong answers — you’re testing the design, not them
-  - [ ] Ask them to think out loud
-  - [ ] Ask “How would you expect this to work?”
-- [ ] Periodically check to see if your teammates have any questions
+### Make sure to {.guide-checklist}
+- Know what you want to learn
+- Demonstrate genuine curiosity
+- Let the conversation flow naturally, and try and get the participant to tell stories — yes, stories — related to the things you’re studying
+- Default to open-ended questions such as “Tell me about a time… ”, “Can you explain…”, “Why do you think…”
+- Ask clarifying questions or ask your interviewee to repeat themselves if you missed something
+- Use a diverse array of question types, such as context-gathering questions (asking about sequences of events, relationships, etc.), clarification questions, and comparison/contrasting questions
+- Use transition phrases to help participants understand when you are moving between parts of the interview (“let’s go back to something you said before”)
+- Test your own assumptions and understandings without asking leading questions. Ask “how” and “why” multiple times, and give the participant sufficient time to think about their answers
+- Note the exact words and phrases people use. Don’t correct them, even their pronunciation, if you think they’re wrong
+- Look people in the eye and give positive affirmations. Lean forward. Say things like “Wow,” or “Oh, interesting!” (when those reactions genuinely occur to you, of course)
+- If you ask the participant to share their screen
+  - Caution them to close anything they don't want recorded beforehand
+  - Assure them that there are no wrong answers — you’re testing the design, not them
+  - Ask them to think out loud
+  - Ask “How would you expect this to work?”
+- Periodically check to see if your teammates have any questions
 
 
 ## Wrap-up
 **Spend 5 minutes** thanking the participant, communicating any next steps, and giving the participant a chance to ask any questions they might have.
 
-### Make sure to
-- [ ] Thank the participant for their time and reiterate the value of their contributions
-- [ ] Ask the participant if there was anything they think we missed or that they would like to add
-- [ ] Ask if it would be okay to contact them again with any follow up questions
-- [ ] Provide any agreed-upon compensation
-- [ ] Turn off the recorder
-- [ ] If possible, ensure the participant that they will receive a copy of what you’ve found during the research (so they know what happened with the input they gave)
-- [ ] If desired, ask them who else you might talk to (fun fact: this is called snowball sampling)
+### Make sure to {.guide-checklist}
+- Thank the participant for their time and reiterate the value of their contributions
+- Ask the participant if there was anything they think we missed or that they would like to add
+- Ask if it would be okay to contact them again with any follow up questions
+- Provide any agreed-upon compensation
+- Turn off the recorder
+- If possible, ensure the participant that they will receive a copy of what you’ve found during the research (so they know what happened with the input they gave)
+- If desired, ask them who else you might talk to (fun fact: this is called snowball sampling)
 
 ## Post-interview activities
 Once the interview is complete, **spend 15 minutes** completing a post-interview debrief. Tend to any post-interview logistics.
 
-### Make sure to
-- [ ] If you’ve recorded the interview: Move any recordings from your Google Drive to the project folder
-- [ ] Engage the team in a post-interview debrief ([example]({{ '/ux-guide/interview-debrief/' | url }})) to discuss surprises and reflect on what you heard
-- [ ] Consider updating the interview guide based on this interview
-- [ ] If you promised the participant any follow-up communications, identify who will send them and when
-- [ ] Optional: Update your study contact list
+### Make sure to {.guide-checklist}
+- If you’ve recorded the interview: Move any recordings from your Google Drive to the project folder
+- Engage the team in a post-interview debrief ([example]({{ '/ux-guide/interview-debrief/' | url }})) to discuss surprises and reflect on what you heard
+- Consider updating the interview guide based on this interview
+- If you promised the participant any follow-up communications, identify who will send them and when
+- Optional: Update your study contact list
 
 
 ## Contributors

--- a/content/ux-guide/resources/participant-agreement.md
+++ b/content/ux-guide/resources/participant-agreement.md
@@ -48,7 +48,9 @@ Contact info: `<researcher name>` `<researcher email>` `<researcher phone>`
 **We’d like to record this session.** We may record video, audio, or photo recordings from this session to help us review our time together and make sure we understood what you shared. We may also share recordings to help tell stories about what people want and need. In all cases we’ll take written notes. We might share quotes from people we interviewed. **Nothing shared will include your face or name.** When the design research project is completed, we’ll delete the full recordings. 
 
 Please check below if you approve recording this session. At any time during the session, you can ask us to stop recording, or you can end the discussion.
-- [ ] I approve recording this session
+
+{.guide-checklist--single}
+  - I approve recording this session
 
 **We’ll work to protect your privacy.** We’ll remove information that could be used to identify you, such as your face or name. (Your voice won’t be removed if you approved recording above.) There’s more information in this [Privacy Act Statement for Design Research [GSA.gov]](https://www.gsa.gov/reference/gsa-privacy-program/privacy-act-statement-for-design-research).
 
@@ -85,7 +87,9 @@ Contact info: `<researcher name>` `<researcher email>` `<researcher phone>`
 **We’d like to record this session.** We may record video, audio, or photo recordings from this session to help us review our time together and make sure we understood what you shared. We may also share recordings to help tell stories about what people want and need. In all cases we’ll take written notes. We might share quotes from people we interviewed. **Nothing shared will include your face or name.** When the design research project is completed, we’ll delete the full recordings. 
 
 Please check below if you approve recording this session. At any time during the session, you can ask us to stop recording, or you can end the discussion. You’d still receive compensation if you end the session early. 
-- [ ] I approve recording this session
+
+{.guide-checklist--single}
+  - I approve recording this session
 
 **We’ll work to protect your privacy.** We’ll remove information that could be used to identify you, such as your face or name. (Your voice won’t be removed if you approved recording above.) There’s more information in this [Privacy Act Statement for Design Research [GSA.gov]](https://www.gsa.gov/reference/gsa-privacy-program/privacy-act-statement-for-design-research).
 

--- a/content/ux-guide/resources/research-alignment-workshop.md
+++ b/content/ux-guide/resources/research-alignment-workshop.md
@@ -37,14 +37,14 @@ As researchers, it's our role to collect *meaningful* information about our user
 
 A research alignment workshop publicizes team questions and prioritizes research themes, setting you up to create a research plan that drives maximum value for your team.
 
-## What you'll need
-- [ ] 1 hour with all key stakeholders + 15 minutes of prep-work
-- [ ] A large room with plenty of white board space
-- [ ] A dedicated note-taker (since you'll be playing the facilitator role, it's extremely helpful to have someone to help you document the session)
-- [ ] Post-it notes
-- [ ] Sharpies
-- [ ] Whiteboard markers
-- [ ] Dot voting stickers
+### What you'll need {.guide-checklist}
+- 1 hour with all key stakeholders + 15 minutes of prep-work
+- A large room with plenty of white board space
+- A dedicated note-taker (since you'll be playing the facilitator role, it's extremely helpful to have someone to help you document the session)
+- Post-it notes
+- Sharpies
+- Whiteboard markers
+- Dot voting stickers
 
 ## Prep-work - 10-15 minutes
 In the workshop, participants (including you!) will be sharing their burning research questions with the team. Prior to the workshop day, have each team member spend 10-15 minutes on a short homework assignment to maximize the efficiency of your workshop and ensure that team members bring thoughtful questions to the session.  


### PR DESCRIPTION
## Changes proposed in this pull request:

- Closes #341
- Handles single checkboxes with a simpler styling (example on `/ux-guide/participant-agreement/`)

## security considerations

None / style change only
