### PR TITLE
adds highlighting to usability test script

### DIFF
--- a/assets/_common/styles/custom-styles.scss
+++ b/assets/_common/styles/custom-styles.scss
@@ -195,3 +195,9 @@ h2.heading-md {
     padding-right: units(1);
   }
 }
+
+/* interview templates */
+
+.example-user-interview-script code {
+  background: yellow;
+}

--- a/assets/methods/styles/_interview-script.scss
+++ b/assets/methods/styles/_interview-script.scss
@@ -1,3 +1,0 @@
-.example-user-interview-script code {
-  background: yellow;
-}

--- a/assets/methods/styles/methods-styles.scss
+++ b/assets/methods/styles/methods-styles.scss
@@ -20,5 +20,4 @@ Custom styling for methods guide only
 @forward "homepage";
 @forward "service-blueprint";
 @forward "usability-test-script";
-@forward "interview-script";
 @forward "print";

--- a/content/ux-guide/resources/usability-test-guide.md
+++ b/content/ux-guide/resources/usability-test-guide.md
@@ -31,6 +31,8 @@ tags: ux-guide
 Note that the permalink here does not include /resources/ so there's no indication where this page actually sits.
 {% endcomment %}
 
+<div class="example-user-interview-script">
+
 This document provides example questions grouped along the key moments usually found in a usability test: introductions, warm up, task completion, follow up, and wrap up. If your participant’s time is scarce, consider sharing a few questions ahead of time. See also this [checklist for running an interview]({{ '/ux-guide/interview-checklist/' | url }}). GSA staff, please see this [Google Doc Template](https://docs.google.com/document/d/1VimyVSt7qK3iKc2uZkobLWM0zuJuvO03vFk_R_EjhOU/edit#).
 
 ## Introduction
@@ -85,3 +87,5 @@ Who else should we talk to?
 
 ## References
 - [Steve Krug’s Usability Test Script](https://sensible.com/downloads/test-script-web.pdf)
+
+</div>


### PR DESCRIPTION
eventually there may not be two separate scripts but until such a time, moved the style into a common location

closes https://github.com/18F/guides/issues/430

## Changes proposed in this pull request:

- adds class to ux-guide user interview script
- moves css style to common location rather than methods specific

## Preview

[Methods version](https://federalist-8bc0b42c-5fd0-4ae8-9366-cd9c265a4446.sites.pages.cloud.gov/preview/18f/guides/jvd-430/methods/interview-script/)

![image](https://github.com/18F/guides/assets/2480492/70971c7b-9625-4a35-834c-a3736661a15f)

[UX Guide version](https://federalist-8bc0b42c-5fd0-4ae8-9366-cd9c265a4446.sites.pages.cloud.gov/preview/18f/guides/jvd-430/ux-guide/usability-test-script/)

![image](https://github.com/18F/guides/assets/2480492/ac3c7cbd-1b7d-445b-8894-2e1091d66656)
