### PR TITLE
Fix H1 headers on method cards

### DIFF
--- a/_includes/layouts/method-card.html
+++ b/_includes/layouts/method-card.html
@@ -5,7 +5,7 @@ layout: layouts/default
 <section class="category category--{{method.category | downcase }} usa-section usa-prose layout--card">
   <header class="category--header" aria-labelledby="{{method_category.title | downcase }}">
     <div class="grid-container">
-      <span class="category--title" id="{{method_category.title | downcase }}">{{ method.category | capitalize }}</span>
+      <h1 class="category--title" id="{{method_category.title | downcase }}">{{ method.category | capitalize }}</h1>
       <p class="category--subtitle">{{ method_categories[method.category].description }}</p>
     </div>
   </header>

--- a/_includes/methods/method.html
+++ b/_includes/methods/method.html
@@ -1,24 +1,24 @@
 <span class="anchor" id="{{ this_method.title | slugify }}"></span>
 <article class="method" itemscope itemtype="http://schema.org/Article">
   <div class="method--panel method--panel--front">
-    <h1 class="method--title" itemprop="headline"><a href="{{ method_path | url }}">
+    <h2 class="method--title" itemprop="headline"><a href="{{ method_path | url }}">
       {% if this_method.title %}
         {{ this_method.title }}
       {% endif %}
-    </a></h1>
+    </a></h2>
       {% capture what_heading_slug %}what-{{ this_method.title | slugify }}{% endcapture %}
-      <h2 id="{{ what_heading_slug }}">What {% include "heading-link.html", slug: what_heading_slug %}</h2>
+      <h3 id="{{ what_heading_slug }}">What {% include "heading-link.html", slug: what_heading_slug %}</h3>
       <p>{{ this_method.what }}</p>
       {% capture why_heading_slug %}why-{{ this_method.title | slugify }}{% endcapture %}
-      <h2 id="{{ why_heading_slug }}">Why {% include "heading-link.html", slug: why_heading_slug %}</h2>
+      <h3 id="{{ why_heading_slug }}">Why {% include "heading-link.html", slug: why_heading_slug %}</h3>
       <p>{{ this_method.why }}</p>
     <footer>
       <section class="method--section method--section--category">
-        <h1>Phase</h1>
+        <h3>Phase</h3>
         <p>{{ this_method.category | capitalize }}</p>
       </section>
       <section class="method--section method--section--time-required">
-        <h1>Time required</h1>
+        <h3>Time required</h3>
         <p>{{ this_method.timeRequired }}</p>
       </section>
     </footer>

--- a/assets/methods/styles/_method.scss
+++ b/assets/methods/styles/_method.scss
@@ -144,7 +144,7 @@
 }
 
 .method--panel--back h4 {
-  font: inherit;
+  font-size: font-size('heading',md);
   font-weight: font-weight('semibold');
   margin-top: 1em;
 }

--- a/assets/methods/styles/_method.scss
+++ b/assets/methods/styles/_method.scss
@@ -64,14 +64,14 @@
   }
 }
 
-.method h2 {
+.method h3 {
   font-size: font-size('heading',lg);
   font-weight: font-weight('bold');
 }
 
 /* custom header link icon color */
-.method h2 span a,
-.method h2 span a:visited {
+.method h3 span a,
+.method h3 span a:visited {
   color: $color-body-dark;
 }
 
@@ -111,7 +111,7 @@
   width: 100%;
 }
 
-.method footer h1 {
+.method footer h3 {
   font-size: font-size('heading',3xs);
   text-transform: uppercase;
 }
@@ -138,7 +138,7 @@
   margin-top: .6em;
 }
 
-.method--panel--back h2 {
+.method--panel--back h3 {
   font-size: font-size('heading',lg);
   margin-top: 1em;
 }

--- a/content/methods/decide/affinity-mapping.md
+++ b/content/methods/decide/affinity-mapping.md
@@ -18,7 +18,7 @@ method:
   category: decide
 ---
 
-## How to do it{#how-to-affinity-mapping}
+### How to do it{#how-to-affinity-mapping}
 
 1. Record ideas, quotes, or observations from [interviews]({{ "/methods/discover/stakeholder-and-user-interviews/" | url }}), [contextual inquiry]({{ "/methods/discover/contextual-inquiry/" | url }}), or other sources of research on sticky notes.
 1. Place the sticky notes on a white board (in no particular arrangement). Move the sticky notes into related groups.
@@ -26,7 +26,7 @@ method:
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#consideration-affinity-mapping}
+### Considerations for use in government{#consideration-affinity-mapping}
 
 No PRA implications. This method may use data gathered from members of the public, but does not require their involvement.
 </section>

--- a/content/methods/decide/comparative-analysis.md
+++ b/content/methods/decide/comparative-analysis.md
@@ -18,7 +18,7 @@ method:
   category: decide
 ---
 
-## How to do it{#how-to-comparative-analysis}
+### How to do it{#how-to-comparative-analysis}
 
 1. Identify a list of services that would be either direct or related competitors to your service.  Pare the list down to four or five.
 1. Establish which criteria or heuristics you will use to evaluate each competing service.
@@ -28,7 +28,7 @@ method:
 
 <section class="method--section method--section--18f-example" markdown="1" >
 
-## Example from TTS{#example-comparative-analysis}
+### Example from TTS{#example-comparative-analysis}
 
 - [Draft U.S. Web Design Standards comparative analysis — USWDS GitHub](https://github.com/18F/web-design-standards/wiki/Comparative-Analysis)
 
@@ -36,7 +36,7 @@ method:
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#considerations-comparative-analysis}
+### Considerations for use in government{#considerations-comparative-analysis}
 
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/content/methods/decide/content-audit.md
+++ b/content/methods/decide/content-audit.md
@@ -18,7 +18,7 @@ method:
   category: decide
 ---
 
-## How to do it{#how-content-audit}
+### How to do it{#how-content-audit}
 
 1. Identify a specific user need or user question that you’d like to address.
 1. Create an inventory of content on your website. Navigate through the site from the home page and note the following about every piece of content. (For repeated items like blog posts, consider capturing just a sample.)
@@ -39,7 +39,7 @@ method:
 
 <section class="method--section method--section--18f-example" markdown="1">
 
-## Example{#ex-content-audit}
+### Example{#ex-content-audit}
 
 - [Content debt: What it is, where to find it, and how to prevent it in the first place — 18F Blog](https://18f.gsa.gov/2016/05/19/content-debt-what-it-is-where-to-find-it-and-how-to-prevent-it-in-the-first-place/){.usa-link .usa-link--external}
 
@@ -47,7 +47,7 @@ method:
 
 <section class="method--section method--section--additional-resources" markdown="1">
 
-## Additional resources{#add-content-audit}
+### Additional resources{#add-content-audit}
 
 - [Content plays: Audit your content — USDA](https://www.usda.gov/digital-strategy/content/plays#content3){.usa-link .usa-link--external}
 
@@ -55,7 +55,7 @@ method:
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#con-content-audit}
+### Considerations for use in government{#con-content-audit}
 
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/content/methods/decide/design-hypothesis.md
+++ b/content/methods/decide/design-hypothesis.md
@@ -21,7 +21,7 @@ method:
   category: decide
 ---
 
-## How to do it{#how-design-hypo}
+### How to do it{#how-design-hypo}
 
 1. As a team, identify and make explicit the problem you’re trying to solve. What goals or needs aren’t being met? What measurable criteria would indicate progress toward those goals?
 
@@ -46,7 +46,7 @@ method:
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#con-design-hypo}
+### Considerations for use in government{#con-design-hypo}
 
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/content/methods/decide/design-principles.md
+++ b/content/methods/decide/design-principles.md
@@ -18,7 +18,7 @@ method:
   category: decide
 ---
 
-## How to do it{#how-design-principals}
+### How to do it{#how-design-principals}
 
 1. Using internal documents and kickoff activities, gather terms or concepts that seem significant to project goals and organizational culture.
 1. Using existing research, list terms or concepts that seem particularly important to customers or user groups.
@@ -29,7 +29,7 @@ method:
 
 <section class="method--section method--section--18f-example" markdown="1" >
 
-## Examples{#ex-design-principals}
+### Examples{#ex-design-principals}
 - 18F Design Principles Guide — [Create](https://github.com/18F/design-principles-guide/blob/18f-pages/pages/create.md), [Define](https://github.com/18F/design-principles-guide/blob/18f-pages/pages/define.md), [Usage](https://github.com/18F/design-principles-guide/blob/18f-pages/pages/usage.md)
 - [Making more consistent decisions with design principles: A new 18F guide — 18F Blog](https://18f.gsa.gov/2016/04/08/making-more-consistent-decisions-with-design-principles-a-new-18f-guide/){.usa-link .usa-link--external}
 
@@ -37,7 +37,7 @@ method:
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#con-design-principals}
+### Considerations for use in government{#con-design-principals}
 
 No PRA implications. Generally, no information is collected from members of the public. Even when stakeholders are members of the public, the PRA explicitly exempts direct observation and non-standardized conversation (e.g., not a survey), 5 CFR 1320.3(h)3. See the methods for
 [Recruiting]({{ "/methods/fundamentals/recruiting/" | url }}) and [Privacy]({{ "/methods/fundamentals/privacy/" | url }}) for more tips on taking input from the public.

--- a/content/methods/decide/interface-audit.md
+++ b/content/methods/decide/interface-audit.md
@@ -18,7 +18,7 @@ method:
   category: decide
 ---
 
-## How to do it{#how-inter-audit}
+### How to do it{#how-inter-audit}
 
 An interface audit can be conducted by an individual or in a group setting. Either way, the steps are as follows:
 1. Identify the website and take screenshots of all the pages you want to audit
@@ -31,14 +31,14 @@ An interface audit can be conducted by an individual or in a group setting. Eith
 
 <section class="method--section method--section--additional-resources" markdown="1">
 
-## Additional resources{#add-inter-audit}
+### Additional resources{#add-inter-audit}
 - [Conducting an interface inventory — Brad Frost](https://bradfrost.com/blog/post/conducting-an-interface-inventory/)
 
 </section>
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Applied in government research{#app-inter-audit}
+### Applied in government research{#app-inter-audit}
 
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/content/methods/decide/journey-mapping.md
+++ b/content/methods/decide/journey-mapping.md
@@ -19,7 +19,7 @@ method:
   content: ./_includes/methods/markdown/journey-mapping.md
 ---
 
-## How to do it{#how-journey-mapping}
+### How to do it{#how-journey-mapping}
 
 1. Document the elements of the project’s design context. This includes:
     - People involved and their related goals
@@ -33,14 +33,14 @@ method:
 
 <section class="method--section method--section--additional-resources" markdown="1">
 
-## Additional resources{#add-journey-mapping}
+### Additional resources{#add-journey-mapping}
 
 - [3-part series on the what, why, and how of journey mapping  — GSA Customer Experience Center of Excellence](https://coe.gsa.gov/2019/04/17/cx-update-9.html){.usa-link .usa-link--external}
 </section>
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#con-journey-mapping}
+### Considerations for use in government{#con-journey-mapping}
 
 No PRA implications. The PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3. See the methods for
 [Recruiting]({{ "/methods/fundamentals/recruiting/" | url }}) and [Privacy]({{ "/methods/fundamentals/privacy/" | url }}) for more tips on taking input from the public.

--- a/content/methods/decide/mental-modeling.md
+++ b/content/methods/decide/mental-modeling.md
@@ -18,7 +18,7 @@ method:
   category: decide
 ---
 
-## How to do it{#how-mental-model}
+### How to do it{#how-mental-model}
 
 1. Create one three-columned table per [persona]({{ "/methods/decide/personas/" | url }}). Label the columns “Past,” “Present behavior,” and “Future.”
 1. In the middle column (Present behavior), list current user behaviors and pain points broadly related to the project, one per row.
@@ -27,7 +27,7 @@ method:
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#con-mental-model}
+### Considerations for use in government{#con-mental-model}
 
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/content/methods/decide/personas.md
+++ b/content/methods/decide/personas.md
@@ -18,7 +18,7 @@ method:
   category: decide
 ---
 
-## How to do it{#how-personas}
+### How to do it{#how-personas}
 
 1. Gather research from earlier activities like [contextual inquiry]({{ "/methods/discover/contextual-inquiry/" | url }}) or [stakeholder interviews]({{ "/methods/discover/stakeholder-and-user-interviews/" | url }}) in a way that’s easy to review. You can create placeholder personas without research to teach user-centered thinking, but because they’re effectively stereotypes, avoid using them for implementable design decisions.
 1. Create a set of user archetypes based on how you believe people will use your solution. These typically get titles (for example, “data administrators” rather than “those who submit data”). Review the archetypes with “who questions:” Who is included? Who is being overlooked? Who is deciding whom to include?
@@ -28,7 +28,7 @@ method:
 
 <section class="method--section method--section--18f-example" markdown="1" >
 
-## Example{#ex-personas}
+### Example{#ex-personas}
 
 - [Personas for Cloud.gov — 18F GitHub](https://github.com/18F/federalist-design/wiki/Personas)
 
@@ -36,7 +36,7 @@ method:
 
 <section class="method--section method--section--additional-resources" markdown="1">
 
-## Additional resources{#add-personas}
+### Additional resources{#add-personas}
 
 - [Improving customer experience with digital personas — Digital.gov](https://digital.gov/2017/06/20/improving-customer-experience-with-digital-personas/){.usa-link .usa-link--external}
 
@@ -44,7 +44,7 @@ method:
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#con-personas}
+### Considerations for use in government{#con-personas}
 
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/content/methods/decide/service-blueprint.md
+++ b/content/methods/decide/service-blueprint.md
@@ -20,7 +20,7 @@ method:
   category: decide
 ---
 
-## How to do it{#how-service}
+### How to do it{#how-service}
 
 1. Gather information on the service through desk research and  [interviews]({{ "/methods/discover/stakeholder-and-user-interviews/" | url }}) with users, frontline staff, and support staff
 2. Create a diagram with four rows:
@@ -32,7 +32,7 @@ method:
 
 <section class="method--section method--section--18f-example" markdown="1" >
 
-## Example from 18F{#ex-service}
+### Example from 18F{#ex-service}
 
 18F created [this service blueprint of getting a burger]({{ "/methods/service-blueprint-example/" | url }}) as an example to illustrate what this could look like
 
@@ -40,7 +40,7 @@ method:
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#con-service}
+### Considerations for use in government{#con-service}
 
 No PRA implications. No information is collected directly from members of the public.
 

--- a/content/methods/decide/site-mapping.md
+++ b/content/methods/decide/site-mapping.md
@@ -18,7 +18,7 @@ method:
   category: decide
 ---
 
-## How to do it{#how-site-mapping}
+### How to do it{#how-site-mapping}
 
 1. List each page of a website or section.
 1. Take a screenshot of each page. Create a thumbnail for each screenshot.
@@ -27,7 +27,7 @@ method:
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#con-site-mapping}
+### Considerations for use in government{#con-site-mapping}
 
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/content/methods/decide/storyboarding.md
+++ b/content/methods/decide/storyboarding.md
@@ -18,7 +18,7 @@ method:
   category: decide
 ---
 
-## How to do it{#how-storyboard}
+### How to do it{#how-storyboard}
 
 1. Gather any documents that describe the different use cases or [scenarios]({{ "/methods/decide/user-scenarios/" | url }}) in which users will interact with your service.
 1. Sketch scenes that visually depict a user interacting with the service, including as much context as possible. For example: Are they on the move? Where are they? What else is in their environment?
@@ -28,7 +28,7 @@ method:
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#con-storyboard}
+### Considerations for use in government{#con-storyboard}
 
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/content/methods/decide/style-tiles.md
+++ b/content/methods/decide/style-tiles.md
@@ -18,7 +18,7 @@ method:
   category: decide
 ---
 
-## How to do it{#how-style-tiles}
+### How to do it{#how-style-tiles}
 
 1. Gather all the feedback and information that was provided during the initial kickoff of the project.
 1. Distill the information into different directions a solution could take. Label these directions based on what kinds of interactions and brand identity they represent.
@@ -27,7 +27,7 @@ method:
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#con-style-tiles}
+### Considerations for use in government{#con-style-tiles}
 
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/content/methods/decide/task-flow-analysis.md
+++ b/content/methods/decide/task-flow-analysis.md
@@ -18,7 +18,7 @@ method:
   category: decide
 ---
 
-## How to do it{#how-task-flow}
+### How to do it{#how-task-flow}
 
 1. Based on user research, identify target users’ goals that need to be analyzed.
 1. For each goal, identify common scenarios and the tasks and decisions that the user or system will perform in each scenario. Don’t assume you and your stakeholders share the same understanding of the tasks. The idea is to make the flow of tasks explicit in the diagram, so that you can check your understanding by walking through the diagram with users (steps 4 & 5).
@@ -28,7 +28,7 @@ method:
 
 <section class="method--section method--section--additional-resources" markdown="1">
 
-## Additional resources{#add-task-flow}
+### Additional resources{#add-task-flow}
 
 - [Task Analysis - Usability.gov](https://www.usability.gov/how-to-and-tools/methods/task-analysis.html){.usa-link .usa-link--external}
 
@@ -36,7 +36,7 @@ method:
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#con-task-flow}
+### Considerations for use in government{#con-task-flow}
 
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/content/methods/decide/user-scenarios.md
+++ b/content/methods/decide/user-scenarios.md
@@ -18,7 +18,7 @@ method:
   category: decide
 ---
 
-## How to do it{#how-user-scenario}
+### How to do it{#how-user-scenario}
 
 1. Determine a few [personas]({{ "/methods/decide/personas/" | url }}) or user groups to focus on. Consider what scenario(s) might be the most critical for that user, including scenarios in which users face limited [accessibility]({{ "/accessibility/" | url }}).
 1. For each user, list out their goals, motivations, and the context/environment in which they interact with your product, service, or website.
@@ -36,7 +36,7 @@ method:
 
 <section class="method--section method--section--additional-resources" markdown="1">
 
-## Additional resources{#add-user-scenario}
+### Additional resources{#add-user-scenario}
 
 - [Scenarios — Usability.gov](https://www.usability.gov/how-to-and-tools/methods/scenarios.html){.usa-link .usa-link--external}
 
@@ -44,7 +44,7 @@ method:
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#con-user-scenario}
+### Considerations for use in government{#con-user-scenario}
 
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/content/methods/discover/cognitive-walkthrough.md
+++ b/content/methods/discover/cognitive-walkthrough.md
@@ -16,7 +16,7 @@ method:
   category: discover
 ---
 
-## How to do it{#how-to-cog-walkthrough}
+### How to do it{#how-to-cog-walkthrough}
 
 1. Identify specific traits for new or infrequent users of a design solution.
 1. Develop a set of representative tasks that emphasize new use or infrequent use.
@@ -29,7 +29,7 @@ method:
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#considerations-cog-walkthrough}
+### Considerations for use in government{#considerations-cog-walkthrough}
 
 No PRA implications. The PRA explicitly exempts direct observation and non-standardized conversation (e.g., not a survey) that a cognitive walkthrough entails, 5 CFR 1320.3(h)3.
 

--- a/content/methods/discover/contextual-inquiry.md
+++ b/content/methods/discover/contextual-inquiry.md
@@ -18,7 +18,7 @@ method:
   category: discover
 ---
 
-## How to do it{#how-contextual-inquiry}
+### How to do it{#how-contextual-inquiry}
 
 1. With permission from a supervisor and from the participant, schedule a time to watch a typical work activity and record data.
 1. While observing, ask the participant to act normally. Pretend you're a student learning how to do the job. Ask questions to help you understand what the person is doing and why.
@@ -27,7 +27,7 @@ method:
 
 <section class="method--section method--section--18f-example" markdown="1" >
 
-## Example{#ex-contextual-inquiry}
+### Example{#ex-contextual-inquiry}
 
 A pair of 18F team members visited two Department of Labor/Wage Hour Division investigators as they interviewed home health care workers who were subject to unpaid overtime and other infractions. Since it was a sensitive subject, the 18F team did not question the health care workers directly, but instead asked the investigators clarifying questions in private. 18F staff also made sure that photos did not include faces.
 
@@ -35,7 +35,7 @@ A pair of 18F team members visited two Department of Labor/Wage Hour Division in
 
 <section class="method--section method--section--additional-resources" markdown="1" >
 
-## Additional resources{#add-contextual-inquiry}
+### Additional resources{#add-contextual-inquiry}
 
 - [Observational research: 5 tips for improving your approach - GOV.UK](https://hodigital.blog.gov.uk/2019/01/18/observational-research-5-tips-for-improving-your-approach){.usa-link .usa-link--external}
 
@@ -43,7 +43,7 @@ A pair of 18F team members visited two Department of Labor/Wage Hour Division in
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#con-contextual-inquiry}
+### Considerations for use in government{#con-contextual-inquiry}
 
 No PRA implications, if done properly. Contextual interviews should be non-standardized, conversational, and based on observation. The PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3. See the methods for
 [Recruiting]({{ "/methods/fundamentals/recruiting/" | url }}) and [Privacy]({{ "/methods/fundamentals/privacy/" | url }}) for more tips on taking input from the public.

--- a/content/methods/discover/design-studio.md
+++ b/content/methods/discover/design-studio.md
@@ -18,7 +18,7 @@ method:
   category: discover
 ---
 
-## How to do it{#how-design-studio}
+### How to do it{#how-design-studio}
 
 1. Invite between six and 12 participants: stakeholders, users, and team members who need to build a shared understanding. Before the meeting, share applicable research, [user personas]({{ "/methods/decide/personas/" | url }}) (unless users will be present), and the design prompt for the exercise.
 1. Bring drawing materials. At the start of the meeting, review the design prompt and research you shared.
@@ -30,7 +30,7 @@ method:
 
 <section class="method--section method--section--18f-example" markdown="1" >
 
-## Example from 18F{#ex-design-studio}
+### Example from 18F{#ex-design-studio}
 
 - [“User-centered design at 18F: a design studio for natural resource revenues”](https://18f.gsa.gov/2014/09/25/design-studio-onrr/){.usa-link .usa-link--external} Chris Cairns , Michelle Hertzfeld , Nick Bristow.
 
@@ -38,7 +38,7 @@ method:
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#con-design-studio}
+### Considerations for use in government{#con-design-studio}
 
 No PRA implications. If conducted with nine or fewer members of the public, the PRA does not apply, 5 CFR 1320.5(c)4. If participants are employees, the PRA does not apply.
 </section>

--- a/content/methods/discover/dot-voting.md
+++ b/content/methods/discover/dot-voting.md
@@ -20,7 +20,7 @@ method:
   category: discover
 ---
 
-## How to do it{#how-dot-voting}
+### How to do it{#how-dot-voting}
 
 1. Bring plenty of sticky notes and colored stickers to the meeting.
 1. Gather everyone on the product team and anyone with a stake in the product.
@@ -32,7 +32,7 @@ method:
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#con-dot-voting}
+### Considerations for use in government{#con-dot-voting}
 
 No PRA implications: dot voting falls under “direct observation”, which is explicitly exempt from the PRA, 5 CFR 1320(h)3. See the methods for [Recruiting]({{ "/methods/fundamentals/recruiting/" | url }}) and [Privacy]({{ "/methods/fundamentals/privacy/" | url }}) for more tips on taking input from the public.
 </section>

--- a/content/methods/discover/five-whys.md
+++ b/content/methods/discover/five-whys.md
@@ -18,7 +18,7 @@ method:
   category: discover
 ---
 
-## How to do it{#how-five-whys}
+### How to do it{#how-five-whys}
 
 Select a particular issue or problem from your user research to investigate further. This could be the most commonly occurring problem or a problem that has been prioritized by the team.
 Ask why the problem occurred and write down an answer. Repeat this process another four times, building off of the previous response each time to drill down to a root cause. As you probe, make sure you remain sensistive to the emotional response of the interviewee. Sometimes asking why multiple times can cause the interviewee to feel frustrated or defensive if they don’t feel as if they are being heard. See example below:
@@ -41,7 +41,7 @@ After getting to a root cause, frame or reframe your problem solving approach to
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#con-five-whys}
+### Considerations for use in government{#con-five-whys}
 
 No PRA implications. No information is collected from members of the public.
 

--- a/content/methods/discover/heuristic-evaluation.md
+++ b/content/methods/discover/heuristic-evaluation.md
@@ -20,7 +20,7 @@ method:
   category: discover
 ---
 
-## How to do it{#how-heuristic-eval}
+### How to do it{#how-heuristic-eval}
 
 1. Recruit a group of three to five people familiar with evaluation methods. These people are not necessarily designers, but are familiar with common usability best practices. They are usually not users.
 1. Ask each person to individually create a list of “heuristics” or general usability best practices. Examples of heuristics from Nielsen’s “10 Usability Heuristics for User Interface Design” include:
@@ -32,7 +32,7 @@ method:
 
 <section class="method--section method--section--additional-resources" markdown="1">
 
-## Additional resources{#add-heuristic-eval}
+### Additional resources{#add-heuristic-eval}
 
 - [10 usability heuristics for user interface design — Nielsen Norman Group](https://www.nngroup.com/articles/ten-usability-heuristics/)
 - [USDA Digital strategy tools — Research — Heuristic review template](https://www.usda.gov/digital-strategy/tools){.usa-link .usa-link--external}
@@ -41,7 +41,7 @@ method:
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#con-heuristic-eval}
+### Considerations for use in government{#con-heuristic-eval}
 
 No PRA Implications, as heuristic evaluations usually include a small number of evaluators. If conducted with nine or fewer members of the public, the PRA does not apply, 5 CFR 1320.5(c)4. If participants are employees, the PRA does not apply. See the methods for [Recruiting]({{ "/methods/fundamentals/recruiting/" | url }}) and [Privacy]({{ "/methods/fundamentals/privacy/" | url }}) for more tips on taking input from the public.
 </section>

--- a/content/methods/discover/hopes-and-fears.md
+++ b/content/methods/discover/hopes-and-fears.md
@@ -18,7 +18,7 @@ method:
   category: discover
 ---
 
-## How to do it{#how-hopes-fears}
+### How to do it{#how-hopes-fears}
 
   1. Ahead of the session, establish what you want to elicit hopes and fears about. For example, you could ask participants to focus on the whole project or that day’s workshop.
   2. At the beginning of the session, create two columns labeled “Hopes” and “Fears” on a white board or large sticky pad.
@@ -31,7 +31,7 @@ This format can be adapted to include other categories. For example, asking part
 
 <section class="method--section method--section--18f-example" markdown="1" >
 
-## Example{#ex-hopes-fears}
+### Example{#ex-hopes-fears}
 
 - [Three small steps you can take to reboot agile in your organization — 18F Blog](https://18f.gsa.gov/2016/10/25/three-small-steps-you-can-take-to-reboot-agile-in-your-organization/){.usa-link .usa-link--external}
 
@@ -40,7 +40,7 @@ This format can be adapted to include other categories. For example, asking part
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#con-hopes-fears}
+### Considerations for use in government{#con-hopes-fears}
 
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/content/methods/discover/kj-method.md
+++ b/content/methods/discover/kj-method.md
@@ -18,7 +18,7 @@ method:
   category: discover
 ---
 
-## How to do it{#how-kj}
+### How to do it{#how-kj}
 
 1. Gather four or more participants for 90 minutes. Provide sticky notes and markers.
 1. Create a focused question about the project’s needs and select a facilitator to run the exercise.
@@ -31,11 +31,11 @@ method:
 
 <section class="method--section method--section--18f-example" markdown="1" >
 
-## Example from 18F{#ex-kj}
+### Example from 18F{#ex-kj}
 
 18F conducted this exercise with 20 Federal Election Commission staff members to define priorities around conflicting requests. We used this method to get data from staff (not the decision makers) about what they saw as the most pressing needs. We synthesized and presented the data back to the decision makers.
 </section>
 
-## Considerations for use in government{#con-kj}
+### Considerations for use in government{#con-kj}
 
 At 18F, KJ participants are almost always federal employees. If there is any chance your KJ workshop could include participants who are not federal employees, consult OMB guidance on the Paperwork Reduction Act and the Privacy Act. Your agency’s Office of General Counsel, and perhaps OIRA desk officers, also can ensure you are following the laws and regulations applicable to federal agencies.

--- a/content/methods/discover/lean-coffee.md
+++ b/content/methods/discover/lean-coffee.md
@@ -18,7 +18,7 @@ method:
   category: discover
 ---
 
-## How to do it{#how-lean-coffee}
+### How to do it{#how-lean-coffee}
 
 1. Give meeting participants two minutes to write what they would like to talk about on sticky notes (one idea per sticky note)
 1. Have meeting participants review the topics generated and [dot vote]({{ "/methods/discover/dot-voting/" | url }}) on the topics they are most interested in
@@ -30,7 +30,7 @@ method:
 
 <section class="method--section method--section--18f-example" markdown="1" >
 
-## Example from 18F{#ex-lean-coffee}
+### Example from 18F{#ex-lean-coffee}
 
 At 18F, Lean coffee is often used to facilitate community of practice meetings and team meetings when the objective is to provide a forum for the meeting attendees to raise issues that are of interest to them. This method provides structure to these meetings and ensures topics are democratically selected for conversation.
 
@@ -38,7 +38,7 @@ At 18F, Lean coffee is often used to facilitate community of practice meetings a
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#con-lean-coffee}
+### Considerations for use in government{#con-lean-coffee}
 
 No PRA implications. No information is collected from members of the public.
 

--- a/content/methods/discover/stakeholder-and-user-interviews.md
+++ b/content/methods/discover/stakeholder-and-user-interviews.md
@@ -18,7 +18,7 @@ method:
   category: discover
 ---
 
-## How to do it{#how-stake}
+### How to do it{#how-stake}
 
   1. Create a guide for yourself of some topics you’d like to ask about, and some specific questions as a back up. Questions will often concern the individual’s role, the organization, the individuals’ needs, and metrics for success of the project. Consider how the interview could harm the participant, and adjust your questions to avoid those hazards. For example, might your questions trigger thoughts of painful experiences?
   1. Sit down one-on-one with the participant, or two-on-one with a note-taker or joint interviewer, in a focused environment. Introduce yourself. Explain the premise for the interview as far as you can without biasing their responses.
@@ -27,7 +27,7 @@ method:
 
 <section class="method--section method--section--additional-resources" markdown="1">
 
-## Additional resources
+### Additional resources
 
 - [Interview checklist]({{ "/methods/interview-checklist/" | url }})
 - [Tips for capturing the best data from user interviews — 18F Blog](https://18f.gsa.gov/2016/02/09/tips-for-capturing-the-best-data-from-user-interviews/){.usa-link .usa-link--external}
@@ -38,7 +38,7 @@ method:
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#con-stake}
+### Considerations for use in government{#con-stake}
 
 No PRA implications. The PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3. See the methods for [Recruiting]({{ "/methods/fundamentals/recruiting/" | url }}) and [Privacy]({{ "/methods/fundamentals/privacy/" | url }}) for more tips on taking input from the public.
 </section>

--- a/content/methods/discover/stakeholder-influence-mapping.md
+++ b/content/methods/discover/stakeholder-influence-mapping.md
@@ -18,7 +18,7 @@ method:
   category: discover
 ---
 
-## How to do it{#how-stake-i}
+### How to do it{#how-stake-i}
 
 1. Gather the team and, ideally, at least one crucial  stakeholder familiar with their organization and how it works from both a technical and an interpersonal point of view.
 1. If meeting in person, you’ll need sticky notes and a whiteboard; if meeting remotely, use a virtual whiteboard or tools that support online document collaboration, ideally simultaneously.
@@ -33,7 +33,7 @@ method:
 
 <section class="method--section method--section--18f-example" markdown="1" >
 
-## Considerations for use in government{#con-stake-i}
+### Considerations for use in government{#con-stake-i}
 
 No PRA implications. No information is collected from members of the public.
 

--- a/content/methods/fundamentals/compensation.md
+++ b/content/methods/fundamentals/compensation.md
@@ -18,7 +18,7 @@ method:
   timeRequired: N/A
 ---
 
-## How to do it{#how-to-compensation}
+### How to do it{#how-to-compensation}
 
 1. Figure out what’s legal and appropriate. Consult your agency’s Office of General Counsel on options for providing compensation to encourage participation in usability testing, consistent with your agency’s authorities. The options will depend upon your agency’s authorities and the specific facts.
 1. Consider contracting for a recruiting service to help you get an effective research pool.
@@ -26,7 +26,7 @@ method:
 
 <section class="method--section method--section--18f-example" markdown="1">
 
-## Example{#example-compensation}
+### Example{#example-compensation}
 
 - [Compensating research participants — TTS Handbook](https://handbook.tts.gsa.gov/18f/how-18f-works/research-guidelines/#compensating-user-research-participants){.usa-link .usa-link--external}
 
@@ -34,11 +34,10 @@ method:
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#considerations-compensation}
+### Considerations for use in government{#considerations-compensation}
 
 No PRA implications. Even when users are present, the PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3.
 
 If you are not working with government employees, you will need to observe standard precautions for archiving personally identifiable information.
 
 </section>
-

--- a/content/methods/fundamentals/privacy.md
+++ b/content/methods/fundamentals/privacy.md
@@ -18,7 +18,7 @@ method:
   timeRequired: N/A
 ---
 
-## How to do it{#how-to-privacy}
+### How to do it{#how-to-privacy}
 
   1. Familiarize yourself with the [Fair Information Practice Principles](https://www.fpc.gov/resources/fipps/){.usa-link .usa-link--external}, a set of precepts at the heart of the U.S. Privacy Act of 1974.
   1. Consult your organization’s privacy office, which may include your general counsel, if you plan to substantially make use of information that could potentially identify specific individuals.
@@ -27,7 +27,7 @@ method:
 
 <section class="method--section method--section--additional-resources" markdown="1">
 
-## Additional resources{#add-privacy}
+### Additional resources{#add-privacy}
 
 - [Doing research at TTS — TTS Handbook](https://handbook.18f.gov/research-guidelines/){.usa-link .usa-link--external}
 - [Privacy — TTS Handbook](https://handbook.tts.gsa.gov/launching-software/privacy){.usa-link .usa-link--external}
@@ -35,7 +35,7 @@ method:
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#con-privacy}
+### Considerations for use in government{#con-privacy}
 
 The government’s use of information about people is subject to a number of laws and policies, including: <a href="https://www.justice.gov/opcl/overview-privacy-act-1974-2020-edition" class="usa-link">the Privacy Act of 1974</a>, the Federal Information Security Management Act of 2002, and the eGovernment Act of 2002.
 

--- a/content/methods/fundamentals/recruiting.md
+++ b/content/methods/fundamentals/recruiting.md
@@ -18,15 +18,15 @@ method:
   timeRequired: 1–2 weeks for 5–10 participants
 ---
 
-## How to do it{#how-recruiting}
+### How to do it{#how-recruiting}
 
-### Seek out people who{#seek-recruiting}
+#### Seek out people who{#seek-recruiting}
 - Are trying to use the thing you are working on right at that very moment.
 - Recently tried to use the thing you are working on.
 - Used the thing you are working on less recently.
 - Have used something like what you are working on, and are likely to use what you are working on.
 
-### Reach them through{#reach-recruiting}
+#### Reach them through{#reach-recruiting}
 - Relevant community organizations.
 - Impromptu requests in or near the relevant environment.
 - Your personal and professional network.
@@ -35,7 +35,7 @@ method:
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#con-recruiting}
+### Considerations for use in government{#con-recruiting}
 
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/content/methods/make/design-pattern-library.md
+++ b/content/methods/make/design-pattern-library.md
@@ -18,7 +18,7 @@ method:
   category: make
 ---
 
-## How to do it{#how-design-pat-lib}
+### How to do it{#how-design-pat-lib}
 
 1. Start identifying common components as early as possible, ideally while you and the team are creating new design elements. These common pieces form the patterns that you will create guidelines for. Specify the components that make up each UI pattern and note possible constraints or restrictions.
 1. Describe or visualize how someone will use the pattern and how it should respond to the user. (For example: how a button renders on load, hover, and click.) Provide any data as to why it is good for the end user.
@@ -28,7 +28,7 @@ method:
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#con-design-pat-lib}
+### Considerations for use in government{#con-design-pat-lib}
 
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/content/methods/make/prototyping.md
+++ b/content/methods/make/prototyping.md
@@ -19,7 +19,7 @@ method:
   category: make
 ---
 
-## How to do it{#how-prototype}
+### How to do it{#how-prototype}
 
 1. Create a rudimentary version of your product. It can be static or functional. Think in the same way you would about a [wireframe]({{ "/methods/make/wireframing/" | url }}): demonstrate structure and relationships among different elements, but don’t worry about stylized elements.
 1. Give the prototype to the user and observe their interactions without instruction.
@@ -29,7 +29,7 @@ method:
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#con-prototype}
+### Considerations for use in government{#con-prototype}
 
 No PRA implications. The PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3. See the methods for
 [Recruiting]({{ "/methods/fundamentals/recruiting/" | url }}) and [Privacy]({{ "/methods/fundamentals/privacy/" | url }}) for more tips on taking input from the public.

--- a/content/methods/make/wireframing.md
+++ b/content/methods/make/wireframing.md
@@ -18,7 +18,7 @@ method:
   category: make
 ---
 
-## How to do it{#how-wireframe}
+### How to do it{#how-wireframe}
 
 1. Build preliminary blueprints that show structure, placement, and hierarchy for your product. Steer clear of font choices, color, or other elements that would distract both the researcher and the reviewer. Lightweight designs are conceptually easier to reconfigure. A few helpful tools for building wireframes are OmniGraffle and Balsamiq, which purposefully keep the wireframe looking like rough sketches.
 1. Use this opportunity to start listing what UX/UI patterns you will need.
@@ -27,7 +27,7 @@ method:
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#con-wireframe}
+### Considerations for use in government{#con-wireframe}
 
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/content/methods/validate/card-sorting.md
+++ b/content/methods/validate/card-sorting.md
@@ -19,24 +19,24 @@ method:
   last_modified_at: example timestamp
 ---
 
-## How to do it{#how-to-card-sort}
+### How to do it{#how-to-card-sort}
 
 There are two types of card sorting: open and closed. Most card sorts are performed with one user at a time, but you can also do the exercise with groups of two to three people.
 
-### Open card sort{#open-card-sort}
+#### Open card sort{#open-card-sort}
 1. Give users a collection of content represented on cards.
 1. Ask users to separate the cards into whatever categories make sense to them.
 1. Ask users to label those categories.
 1. Ask users to tell you why they grouped the cards and labeled the categories as they did.
 
-### Closed card sort{#closed-card-sort}
+#### Closed card sort{#closed-card-sort}
 1. Give users a collection of content represented on cards.
 1. Ask users to separate the cards into a list of categories you have predefined.
 1. Ask users to tell you why they assigned cards to the categories they did.
 
 <section class="method--section method--section--18f-example" markdown="1" >
 
-## Example from 18F{#ex-card-sort}
+### Example from 18F{#ex-card-sort}
 
 - [Research plan including card sorting from 18F’s C2 project — 18F GitHub](https://github.com/18F/C2/wiki/Sprint-5:-Interaction-model-June-2016)
 
@@ -44,7 +44,7 @@ There are two types of card sorting: open and closed. Most card sorts are perfor
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#con-card-sort}
+### Considerations for use in government{#con-card-sort}
 
 No PRA implications if done as directly moderated sessions. The PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3.
 </section>

--- a/content/methods/validate/multivariate-testing.md
+++ b/content/methods/validate/multivariate-testing.md
@@ -19,7 +19,7 @@ method:
   last_modified_at: example timestamp
 ---
 
-## How to do it{#how-multivariate}
+### How to do it{#how-multivariate}
 
 1. Identify the call to action, content section, or feature that needs to be improved to increase conversion rates or user engagement.
 1. Develop a list of possible issues that may be hurting conversion rates or engagement. Specify in advance what you are optimizing for (possibly through [design hypothesis]({{ "/methods/decide/design-hypothesis/" | url }})).
@@ -29,7 +29,7 @@ method:
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#con-multivariate}
+### Considerations for use in government{#con-multivariate}
 
 No PRA implications. No one asks the users questions, so the PRA does not apply. See the methods for
 [Recruiting]({{ "/methods/fundamentals/recruiting/" | url }}) and [Privacy]({{ "/methods/fundamentals/privacy/" | url }}) for more tips on taking input from the public.

--- a/content/methods/validate/usability-testing.md
+++ b/content/methods/validate/usability-testing.md
@@ -19,7 +19,7 @@ method:
   last_modified_at: example timestamp
 ---
 
-## How to do it{#how-usability}
+### How to do it{#how-usability}
 
 1. Pick what you’ll test. Choose something, such as a sketch, [prototype]({{ "/methods/make/prototyping/" | url }}), or even a "competitor’s product" that might help users accomplish their goals.
 1. Plan the test. Align your team on the scenarios the test will focus on, which users should participate (and how you’ll [recruit]({{ "/methods/fundamentals/recruiting/" | url }}) them), and which team members will moderate and observe. Prepare a [usability test script]({{ "/methods/usability-test-script/" | url }}).
@@ -30,7 +30,7 @@ main
 
 <section class="method--section method--section--18f-example" markdown="1" >
 
-## Examples from 18F{#ex-usability}
+### Examples from 18F{#ex-usability}
 
 - [Usability testing plans from 18F’s Extractive Industries Transparency Initiative project with Department of the Interior — Office of Natural Resources Revenue GitHub](https://github.com/ONRR/doi-extractives-data/blob/research/research/summary-jan2016.md)
 
@@ -38,7 +38,7 @@ main
 
 <section class="method--section method--section--additional-resources" markdown="1">
 
-## Additional resources{#add-usability}
+### Additional resources{#add-usability}
 
 - [Introduction to remote moderated usability testing, part 1: What and why — 18F Blog](https://18f.gsa.gov/2018/11/14/introduction-to-remote-moderated-usability-testing-part-1/){.usa-link .usa-link--external}
 - [Introduction to remote moderated usability testing, part 2: How — 18F Blog](https://18f.gsa.gov/2018/11/20/introduction-to-remote-moderated-usability-testing-part-2-how/){.usa-link .usa-link--external}
@@ -52,7 +52,7 @@ main
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government
+### Considerations for use in government
 
 No PRA implications. First, any given usability test should involve nine or fewer users. Additionally, the PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3. It also specifically excludes tests of knowledge or aptitude, 5 CFR 1320.3(h)7, which is essentially what a usability test tests. See the methods for
 [Recruiting]({{ "/methods/fundamentals/recruiting/" | url }}) and [Privacy]({{ "/methods/fundamentals/privacy/" | url }}) for more tips on taking input from the public.

--- a/content/methods/validate/visual-preference-testing.md
+++ b/content/methods/validate/visual-preference-testing.md
@@ -20,7 +20,7 @@ method:
   last_modified_at: example timestamp
 ---
 
-## How to do it{#how-visual-preference}
+### How to do it{#how-visual-preference}
 
 1. Create iterations of a [style tiles]({{ "/methods/decide/style-tiles/" | url }}) or other asset that represent directions a final visual design may follow. If branding guidelines or attributes don’t exist, establish them with stakeholders beforehand.
 1. Interview participants about their reactions.
@@ -32,7 +32,7 @@ method:
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#con-visual-preference}
+### Considerations for use in government{#con-visual-preference}
 
 No PRA implications. The PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3. See the methods for
 [Recruiting]({{ "/methods/fundamentals/recruiting/" | url }}) and [Privacy]({{ "/methods/fundamentals/privacy/" | url }}) for more tips on taking input from the public.


### PR DESCRIPTION
## Changes proposed in this pull request:

- Make sure the method category is the only H1 on the page. For example, **Discover** or **Validate**. (method-card.html)
- Make sure the method category is the only H1 on the "See all cards" page (method-category.html).
- Change PHASE and TIMING H1s to H2 elements
- Bump down other headings down one level (H2 to H3, etc) for each card front panel (method.html) and back panel (*.md) 
- Update CSS to match styles as designed.

## Security considerations

No security considerations, since this is just html and markdown files.

## Acceptance criteria (for Reviewer)

- [ ] HTML outline will show only one H1 on a single card and a collection of cards.
- [ ] Styles look the same, even though the headings have been bumped down.

[Preview URL of one card](https://federalist-8bc0b42c-5fd0-4ae8-9366-cd9c265a4446.sites.pages.cloud.gov/preview/18f/guides/447-fix-h1-headers-ca/methods/validate/card-sorting/)

[Preview URL of one card collection](https://federalist-8bc0b42c-5fd0-4ae8-9366-cd9c265a4446.sites.pages.cloud.gov/preview/18f/guides/447-fix-h1-headers-ca/methods/validate/)

Using the **headingsMap** tool:
_Before_
![image](https://github.com/18F/guides/assets/381122/c9ba742e-a071-4e72-9fd6-3bdb6893e5a5)

_After_
![image](https://github.com/18F/guides/assets/381122/b01b6d93-8e68-4be8-a5e2-2261d659aa43)
