### PR TITLE
Remove methods.18f.gov from redirect_bases yaml.

### DIFF
--- a/_data/redirect_bases.yaml
+++ b/_data/redirect_bases.yaml
@@ -1,1 +1,1 @@
-methods: https://methods.18f.gov/
+# Removing a guide from this yaml file will make the guide indexable for search.gov and other web crawlers.


### PR DESCRIPTION
## Changes proposed in this pull request:

Remove methods.18f.gov URL from redirect_bases.yaml, according to the [steps to migrate a guide](https://docs.google.com/document/d/19b1Y2pSyw1EjXzc2XmL-qXqQCfqiVQLkypOO8zJKUKw/edit), 

