### PR TITLE
Fix common typos for the word "the"

### DIFF
--- a/content/accessibility/headings.md
+++ b/content/accessibility/headings.md
@@ -75,7 +75,7 @@ lorum ipsum
 </div>
 ```
 
-> This section has a main category and two sub categories. The sub categories are on the same level and as such use the the same heading element.
+> This section has a main category and two sub categories. The sub categories are on the same level and as such use the same heading element.
 
 ### Fails
 

--- a/content/methods/interview-checklist.md
+++ b/content/methods/interview-checklist.md
@@ -53,7 +53,7 @@ eleventyExcludeFromCollections: true
 - Be polite; you’re a guest in the participant’s world
 - Give the participant your full attention (You can signal this by making eye contact, asking follow up questions, etc. Be aware that taking notes, especially on a laptop, can distract from the conversation itself)
 - Ask open-ended questions that will give you relevant information and help you form a better understanding of who this person is
-- Understand the degree to which this person is comfortable talking about themselves and their work, and at what speed. Be mindful and respectful of anything the the participant is uncomfortable talking about
+- Understand the degree to which this person is comfortable talking about themselves and their work, and at what speed. Be mindful and respectful of anything the participant is uncomfortable talking about
 - Give the participant time to respond; don’t be afraid of awkward pauses
 - Ask for a “tour”: note any organizations, tools, rituals, or processes that affect your participant’s perspective
 - Start broad (“So to start, could you tell us how you got into this line of work?” or “What’s a day in your work-life like?”), and then slowly direct the interview toward any planned activities (“Could you share your screen and show me how you do that?”) or topic-specific questions (“How often do you file TPS reports?”)

--- a/content/ux-guide/resources/interview-checklist.md
+++ b/content/ux-guide/resources/interview-checklist.md
@@ -70,7 +70,7 @@ Note that the permalink here does not include /resources/ so there's no indicati
 - Be polite; you’re a guest in the participant’s world
 - Give the participant your full attention (You can signal this by making eye contact, asking follow up questions, etc. Be aware that taking notes, especially on a laptop, can distract from the conversation itself)
 - Ask open-ended questions that will give you relevant information and help you form a better understanding of who this person is
-- Understand the degree to which this person is comfortable talking about themselves and their work, and at what speed. Be mindful and respectful of anything the the participant is uncomfortable talking about
+- Understand the degree to which this person is comfortable talking about themselves and their work, and at what speed. Be mindful and respectful of anything the participant is uncomfortable talking about
 - Give the participant time to respond; don’t be afraid of awkward pauses
 - Ask for a “tour”: note any organizations, tools, rituals, or processes that affect your participant’s perspective
 - Start broad (“So to start, could you tell us how you got into this line of work?” or “What’s a day in your work-life like?”), and then slowly direct the interview toward any planned activities (“Could you share your screen and show me how you do that?”) or topic-specific questions (“How often do you file TPS reports?”)

--- a/docs/development.md
+++ b/docs/development.md
@@ -175,7 +175,7 @@ You can also set a custom page title using `seo_title` in the front matter, to i
 By default, the `title` front matter will be rendered as an `h1` element. There are two additional front matter options that control the markup for the title:
 
 - `page_title_tag`: When you need the title of the page to be something other than H1, use this. This takes the name of the tag only, like `h2` or `div` — don't set the full tag like `<h3>`.
-- `hidden_guide_title`: If added, this will take the value of `hidden_guide_title` and render a screen reader only `h1` element before teh `page_title_tag`. This option is meant to be used together with the `page_title_tag`.
+- `hidden_guide_title`: If added, this will take the value of `hidden_guide_title` and render a screen reader only `h1` element before the `page_title_tag`. This option is meant to be used together with the `page_title_tag`.
 
 Example usage:
 ```


### PR DESCRIPTION
## Changes proposed in this pull request:

- Replace "the the" and "teh" with "the"



