### PR TITLE
Remove aria-label on div element

### DIFF
--- a/_includes/usa_identifier.html
+++ b/_includes/usa_identifier.html
@@ -12,7 +12,7 @@
           {% image_with_class "assets/_common/_img/gsa-logo-blue.svg" "usa-identifier__logo-img" "gsa logo" %}
         </a>
       </div>
-      <div class="usa-identifier__identity text-base-lightest" aria-label="Agency description">
+      <div class="usa-identifier__identity text-base-lightest">
         <p class="usa-identifier__identity-domain">18F {{ titles_roots[guide].title }}</p>
         <p class="usa-identifier__identity-disclaimer text-base-lightest">An official website of the
           <a href="https://www.gsa.gov/about-us/organization/federal-acquisition-service/technology-transformation-services">


### PR DESCRIPTION
## Changes proposed in this pull request:

- Remove `aria-label="Agency description"` from a `<div>` element

## Reasons:

- The label is not allowed on `<div>` elements [by html-validate](https://html-validate.org/rules/aria-label-misuse.html)
- Which is causing HTML validation dependabot updates [like this one](https://github.com/18F/guides/pull/494) to fail

## Considerations:

- 🤔 Are there a11y concerns? 

