### PR TITLE
Update UX Guide title

### DIFF
--- a/_data/titles_roots.yaml
+++ b/_data/titles_roots.yaml
@@ -27,7 +27,7 @@ product:
   title: Product Guide
   root: /product/
 ux-guide:
-  title: User Experience Design Guide
+  title: User Experience Guide
   root: /ux-guide/
 methods:
   title: Methods


### PR DESCRIPTION
Remove the word "Design" from the title of the User Experience Guide, per the [TLC ticket](https://github.com/18F/guides/issues/465) and previous [merged PR](https://github.com/18F/guides/pull/467/files). 