### PR TITLE
Clarify the role of the home page in the guides repo

### DIFF
--- a/_includes/guidelist.html
+++ b/_includes/guidelist.html
@@ -1,74 +1,74 @@
 <section class="usa-section border-1 border-primary-dark">
   <div class="grid-container">
-  <h2> Some approaches and stuff</h2>
+  <h2>Links to actual guides as they appear online</h2>
     <div class="grid-row grid-gap">
       <div class="grid-col-6 tablet:grid-col-3 margin-top-2">
         <a href="{{'/accessibility/' | url }}">
           {% image_with_class "assets/_common/_img/guide_icons/accessibility.svg" "maxw-6" "" %}
-          <p>So accessibiliity</p>
+          <p>{{ titles_roots["accessibility"].title }}</p>
         </a>
       </div>
 
       <div class="grid-col-6 tablet:grid-col-3 margin-top-2">
         <a href="{{'/agile/' | url }}">
           {% image_with_class "assets/_common/_img/guide_icons/agile.svg" "maxw-6" "" %}
-          <p>So agile</p>
+          <p>{{ titles_roots["agile"].title }}</p>
         </a>
       </div>
 
       <div class="grid-col-6 tablet:grid-col-3 margin-top-2">
         <a href="{{'/brand/' | url }}">
           {% image_with_class "assets/_common/_img/guide_icons/brand.svg" "maxw-6" "" %}
-          <p>Such brand</p>
+          <p>{{ titles_roots["brand"].title }}</p>
         </a>
       </div>
 
       <div class="grid-col-6 tablet:grid-col-3 margin-top-2">
         <a href="{{'/content-guide/' | url }}">
           {% image_with_class "assets/_common/_img/guide_icons/content.svg" "maxw-6" "" %}
-          <p>Very content-guide </p>
+          <p>{{ titles_roots["content-guide"].title }}</p>
         </a>
       </div>
 
       <div class="grid-col-6 tablet:grid-col-3 margin-top-2">
         <a href="{{'/derisking/' | url }}">
           {% image_with_class "assets/_common/_img/guide_icons/derisking.svg" "maxw-6" "" %}
-          <p> Such derisking </p>
+          <p>{{ titles_roots["derisking"].title }}</p>
         </a>
       </div>
 
       <div class="grid-col-6 tablet:grid-col-3 margin-top-2">
         <a href="{{'/eng-hiring/' | url }}">
           {% image_with_class "assets/_common/_img/team-lg.svg" "maxw-6" "" %}
-          <p>Much hiring of engineers</p>
+          <p>{{ titles_roots["eng-hiring"].title }}</p>
         </a>
       </div>
 
       <div class="grid-col-6 tablet:grid-col-3 margin-top-2">
         <a href="{{'/product/' | url }}">
           {% image_with_class "assets/_common/_img/guide_icons/product.svg" "maxw-6" "" %}
-          <p>Product guide (Wow)</p>
+          <p>{{ titles_roots["product"].title }}</p>
         </a>
       </div>
 
       <div class="grid-col-6 tablet:grid-col-3 margin-top-2"> 
         <a href="{{'/ux-guide/' | url }}"> 
           {% image_with_class "assets/_common/_img/guide_icons/user-interviews-love--c.svg" "maxw-6" "" %}
-          <p>So much UX all the time</p>
+          <p>{{ titles_roots["ux-guide"].title }}</p>
         </a>
       </div>
 
       <div class="grid-col-6 tablet:grid-col-3 margin-top-2"> 
         <a href="{{'/engineering/' | url }}"> 
           {% image_with_class "assets/_common/_img/guide_icons/engineering.svg" "maxw-6" "" %}
-          <p>Engineering whoa</p>
+          <p>{{ titles_roots["engineering"].title }}</p>
         </a>
       </div>
 
       <div class="grid-col-6 tablet:grid-col-3 margin-top-2">
         <a href="{{'/methods/' | url }}">
           {% image_with_class "assets/_common/_img/guide_icons/content.svg" "maxw-6" "" %}
-          <p>Methods</p>
+          <p>{{ titles_roots["methods"].title }}</p>
         </a>
       </div>
 

--- a/_includes/hero.html
+++ b/_includes/hero.html
@@ -5,10 +5,11 @@ This will be displayed on the homepage. Ideally, you want to highlight key goals
 <section class="usa-hero">
   <div class="grid-container">
     <div class="usa-hero__callout">
-      <h1 class="usa-hero__heading"><span class="usa-hero__heading--alt">Hero callout:</span>Bring attention to a project priority
+      <h1 class="usa-hero__heading">This is not the Guides home page
       </h1>
-      <p>Support the callout with some short explanatory text. You don’t need more than a couple of sentences.</p>
-      <a class="usa-button" href="javascript:void(0)">Call to action</a>
+      <p>On the web, this home page does not appear. Look into the individual
+      guides below for the actual Guides content.</p>
+      <a class="usa-button" href="javascript:void(0)">Look elsewhere</a>
     </div>
   </div>
 </section>

--- a/_includes/hero.html
+++ b/_includes/hero.html
@@ -7,9 +7,9 @@ This will be displayed on the homepage. Ideally, you want to highlight key goals
     <div class="usa-hero__callout">
       <h1 class="usa-hero__heading">This is not the Guides home page
       </h1>
-      <p>On the web, this home page does not appear. Look into the individual
+      <p>On the web, this home page does not appear. The actual guides homepage lives in the 18F.gsa.gov repository. Look into the individual
       guides below for the actual Guides content.</p>
-      <a class="usa-button" href="javascript:void(0)">Look elsewhere</a>
+      <a class="usa-button" href="https://18f.gsa.gov/guides/">Leave to visit the actual Guides homepage</a>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Changes proposed in this pull request:

The `index.html` page in this repository doesn't actually appear online at guides.18f.gov/. But in a Cloud.gov Pages preview, we do see that page. This can be confusing, so this PR adds content on the `index.html` page that tries to explain the situation.

## security considerations

HTML content-only change so no security implications.