### PR TITLE
Add 'f' to the email address for 18F

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -5,7 +5,7 @@
         <div class="grid-col usa-dark-background">
           <p class="margin-bottom-0 text-white"> This project is maintained by <a class="usa-link text-primary-dark" href="https://18f.gsa.gov/">18F</a></p>
           <p class="margin-bottom-0 margin-top-05 text-white"> Learn more about our <a class="usa-link text-primary-dark" href="https://18f.gsa.gov/linking-policy/">Linking Policy</a></p>
-          <p class="margin-top-05 text-white"> Have questions or would like to contact us? Email us at <a class="usa-link text-primary-dark" href="mailto:18@gsa.gov">18F@gsa.gov</a></p>
+          <p class="margin-top-05 text-white"> Have questions or would like to contact us? Email us at <a class="usa-link text-primary-dark" href="mailto:18f@gsa.gov">18F@gsa.gov</a></p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Changes proposed in this pull request:

- Fixed the mailto link in the footer so that it correctly sends to 18f@gsa.gov, fixes #527 

## security considerations

None
