### PR TITLE
[Guides] Fixing typos and adjusting language for clarity

### DIFF
--- a/content/content-guide/our-approach/keep-refining.md
+++ b/content/content-guide/our-approach/keep-refining.md
@@ -83,7 +83,7 @@ If you genuinely need to delete something, give users a path to find what they n
 
 - [A Sestina on Sunsetting Content](https://18f.gsa.gov/2016/05/23/a-sestina-on-sunsetting-content/), 18F Blog
 - [Guidance on Managing Web Records](https://www.archives.gov/records-mgmt/policy/managing-web-records-index.html), National Archives and Records Administration
-- [Withdrawing and Unpublishing Content, and Labelling Content from Previous Governments](https://www.gov.uk/guidance/content-design/gov-uk-content-retention-and-withdrawal-archiving-policy), GOV.UK
+- [Withdrawing or Unpublishing Content, and Content from Previous Governments](https://www.gov.uk/guidance/content-design/gov-uk-content-retention-and-withdrawal-archiving-policy), GOV.UK
 - [Unpublishing and Withdrawing ('Archiving')](https://www.gov.uk/guidance/how-to-publish-on-gov-uk/unpublishing-and-archiving), GOV.UK
 - [Best Practice for Archiving and Deleting Content](http://www.contentstrategyinc.com/best-practices-for-archiving-and-deleting-content/), Content Strategy Inc.
 - [How Should You Handle Expired Content?](https://moz.com/blog/how-should-you-handle-expired-content), Moz

--- a/content/content-guide/our-style/inclusive-language.md
+++ b/content/content-guide/our-style/inclusive-language.md
@@ -40,7 +40,7 @@ This page is not exhaustive, but aims to provide principles, resources, and spec
 
 ## Ability and disability
 
-Every person is a whole person — no matter how they interact with the world. Focus on what they need to do, what tools they use, and avoid making assumptions. If a person’s situation, medical condition, illness, or injury is relevant to the content, be as specific as possible and avoid inserting value judgements about their circumstance (for example, use _has multiple sclerosis_, not _is afflicted with_ or _suffers from_).
+Every person is a whole person — no matter how they interact with the world. Focus on what they need to do, what tools they use, and avoid making assumptions. If a person’s situation, medical condition, illness, or injury is relevant to the content, be as specific as possible and avoid inserting value judgments about their circumstance (for example, use _has multiple sclerosis_, not _is afflicted with_ or _suffers from_).
 
 Just like with language around race, gender, or other identities, it’s always best to ask people how they identify rather than assuming. For help finding appropriate or accurate language, see the [Disability Language Style Guide](http://ncdj.org/style-guide/) from the National Center on Disability and Journalism.
 

--- a/content/derisking/federal-field-guide/5-doing-the-work.md
+++ b/content/derisking/federal-field-guide/5-doing-the-work.md
@@ -136,7 +136,7 @@ Program or oversight staff can join sprint reviews periodically. Meetings are of
 The United Kingdom's National Audit Office's [Governance for Agile delivery](https://www.nao.org.uk/wp-content/uploads/2012/07/governance_agile_delivery.pdf) explains how to perform assessments, specifically section in 3.5, "Principles for governance":
 
 > External assessment or reviews of agile delivery should focus on the
-> teams' behaviours and not just processes and documentation. Assessors
+> teams' behaviors and not just processes and documentation. Assessors
 > are more effective in providing critical challenges if they have
 > high-end skills, including technical and agile delivery experience. In
 > addition, they provide better value if they continually review how the

--- a/content/engineering/languages-runtimes/css.md
+++ b/content/engineering/languages-runtimes/css.md
@@ -579,7 +579,7 @@ There’s a tool that can graph your files’ specificity, [CSS specificity grap
 * [Explanation](http://csswizardry.com/2014/10/the-specificity-graph/)
 
 ### Rationale
-With specificity comes great responsibility. Broad selectors allow us to be efficient, yet can have adverse consequences if not tested. Location-specific selectors can save us time, but will quickly lead to a cluttered stylesheet. Exercise your best judgement to create selectors that find the right balance between contributing to the overall style and layout of the DOM.
+With specificity comes great responsibility. Broad selectors allow us to be efficient, yet can have adverse consequences if not tested. Location-specific selectors can save us time, but will quickly lead to a cluttered stylesheet. Exercise your best judgment to create selectors that find the right balance between contributing to the overall style and layout of the DOM.
 
 * When modifying an existing element for a specific use, try to use specific class names. Instead of `.listings-layout.bigger` use rules like `.listings-layout.listings-bigger`. Think about ack/grepping your code in the future.
 * Use lowercase and separate words with hyphens when naming selectors. Avoid camelcase and underscores. Use human-readable selectors that describe what element(s) they style.

--- a/content/engineering/languages-runtimes/javascript.md
+++ b/content/engineering/languages-runtimes/javascript.md
@@ -139,7 +139,7 @@ When choosing a JavaScript web framework, also consider if vanilla JavaScript wo
 #### When to use
 - Single page apps that requires data manipulation on the front end without a server side request/response architecture.
 - When there's a strong need to render JavaScript based UI on the server due to performance or accessibility reasons.
-- JavaScript UI that incorperates many nested components.
+- JavaScript UI that incorporates many nested components.
 - A UI with many components and updates that needs to be performance conscious.
 - When only a "view" framework is desired/required.
 - To ensure all front-end components conform to a single standard.

--- a/content/engineering/our-approach/release-strategies.md
+++ b/content/engineering/our-approach/release-strategies.md
@@ -39,7 +39,7 @@ Big bang releases heighten the risk of unknowns that can crop up as the release 
 #### Release to different user groups at different times
 **Recommendation**: Release to a subset of users at a time. This lets you test, creates a better user experience for them, and a better time post-release for your team.
 
-There are always going to be immediate bug fixes and customer asks in the aftermath of a release. Initally scoping a big release to a subset of user types at a time will narrow the developer and customer success team's focus, making debugging and prioritizing fixes easier.
+There are always going to be immediate bug fixes and customer asks in the aftermath of a release. Initially scoping a big release to a subset of user types at a time will narrow the developer and customer success team's focus, making debugging and prioritizing fixes easier.
 
 #### Practice data migrations often
 **Recommendation**: Do dry runs of any critical data or infrastructure migrations.
@@ -64,7 +64,7 @@ Launches often have predictable support requests, such as:
 * "This is broken."
 * "I can't find Z."
 
-Preparing responses ahead of time allows the customer support team to give the same suppport to anyone facing a predictable issue, allowing them to focus their energies on unexpected support needs. It also helps ensure a better, customer experience as users are consistently given thorough and well-thought-out answers to these common problems.
+Preparing responses ahead of time allows the customer support team to give the same guidance to anyone facing a predictable issue, allowing them to focus their energies on unexpected support needs. It also helps ensure a better, customer experience as users are consistently given thorough and well-thought-out answers to these common problems.
 
 ### Pushing back against Big Bang Release releases
 Partners are often deeply attached to big bang releases, but there are strategies you can deploy to try to convince partners to pivot to a smaller, more iterative release strategy.
@@ -84,7 +84,7 @@ Partners have a valid fear of the ATO process, and may be nervous that they must
 *Mitigation strategies:*
 * Engage security and ATO personnel early in the development process, or, ideally, embed someone onto the project team who can help advise. This strategy (among other improvements) helped GSA bring average ATO time from [six months to thirty days](https://18f.gsa.gov/2018/07/19/taking-the-ato-process-from-6-months-to-30-days/).
 * Familiarize yourself with TTS's [Launching Software](https://handbook.tts.gsa.gov/#launching-software) strategies so you can personally help alleviate some of their concerns.
-* Teams at 18F have also found success in employing the "Walking Skeleton" technique, where the main architectural components of a system are deployed early in a minumum viable way. Frontloading the infrastructure work creates an MVP for ATO work, and makes space for early compliance and security oversight.
+* Teams at 18F have also found success in employing the "Walking Skeleton" technique, where the main architectural components of a system are deployed early in a minimum viable way. Frontloading the infrastructure work creates an MVP for ATO work, and makes space for early compliance and security oversight.
 
 #### Legislative mandate
 When the system is a byproduct of a legislative mandate, there can be political or legal implications if a deadline is missed.  A mandate for a specific type or level of service may make partners wary of more iterative work.

--- a/content/product/partners/vendor.md
+++ b/content/product/partners/vendor.md
@@ -63,6 +63,6 @@ If 18F is brought in to help a partner that has an existing relationship with a 
 
 - [QASP Example [1]](https://derisking-guide.18f.gov/qasp/): QASP criteria from 18F’s de-risking guide.
 
-- [Acquistions toolkit](https://drive.google.com/drive/folders/1rj0lYJVjhClDQLLf-Hua_Xr6YtJAAN_X): Guidance and templates on acquisitions, contracting, and procurement.
+- [Acquisitions toolkit](https://drive.google.com/drive/folders/1rj0lYJVjhClDQLLf-Hua_Xr6YtJAAN_X): Guidance and templates on acquisitions, contracting, and procurement.
 
 - <a href="https://app.mural.co/t/gsa6/m/gsa6/1611637931895/f601104204b8159db7364ca7b97e807b19b06b84" class="private-link">Post-award management</a>: Common best practices and risks that exist around post-award management and vendor relationships.

--- a/content/ux-guide/research/make-research-actionable.md
+++ b/content/ux-guide/research/make-research-actionable.md
@@ -164,7 +164,7 @@ We most commonly share our research findings via presentations. These presentati
 Avoid stereotyping and generalizing in how you present findings, especially when talking about underserved communities and historically marginalized groups. Critically look at the quotes and information collected to determine if a quote may reinforce stereotypes.
 
 - Contextualize quotes from participants. You should not assume identity based on appearance, rely solely on a participant’s self-identification.
-- Resist flattening complexity by oversimplifying peoples' expereinces by making the inherent complexity clearer. 
+- Resist flattening complexity by oversimplifying peoples' experiences by making the inherent complexity clearer. 
 - Instead of “LGBT+ people felt included with our new form design.” Try something like, “The two participants who selected the non-binary gender option remarked this addition made them feel included.”
 - Methodological triangulation (using multiple data sets; for example, augmenting qualitative interview data with quantitative statistical data) can help minimize the risk of unintentionally perpetuating biases expressed by individual interview participants
 

--- a/content/ux-guide/research/plan.md
+++ b/content/ux-guide/research/plan.md
@@ -61,7 +61,7 @@ Describe factors that the research will need to account for, including any share
 
 Design research is fundamentally about reducing risk and informing decisions. When writing your goals, use verbs that specify the output like “describe,” “evaluate,” “quantify,” or “identify.” Avoid vague words like “understand” or “explore.” Example goals could include: “describe user goals and pain points,” or “identify and evaluate the hypothesis behind our proposed design.”
 
-Make sure your goals work towards concrete positive change for your audiences. Goals poorly written can reinforce structural problems or only adress surface level issues. 
+Make sure your goals work towards concrete positive change for your audiences. Poorly-written goals can reinforce structural problems or only address surface level issues. 
 
 Research can also have subgoals. For example, some agencies choose to work with 18F to learn more about our approach. Explicitly stating these kinds of subgoals helps provide an honest account of the coaching work that the team will undertake alongside the research itself.
 
@@ -75,7 +75,7 @@ Next, engage your team in a conversation about bias. Bias is always present in r
 
 ### Research questions
 
-Research questions are high-level questions that reflect what you want to learn to make better evidence-based decisions. Research questions are different from interview questions. Research questions should be relevant, actionable, and practical. They should also be [ethical]({{ '../../research/ethics/' | url }}): consider whether answering your research questions would put participants in a compromising position. For example, studying the degree to which participants adhere to a law or policy enforced by the researcher’s own office or institution could jeopardize participants’ careers and/or pose authority and coercion issues. Take care when asking participants questions that might unintentionally exclude or harm interviewees. It’s your responsibility to make sure that participants' experience in your research session as smooth and painless as possible expecially when asking about what isn’t working about a product/service, or bringing up potentially sensitive emotional experiences. 
+Research questions are high-level questions that reflect what you want to learn to make better evidence-based decisions. Research questions are different from interview questions. Research questions should be relevant, actionable, and practical. They should also be [ethical]({{ '../../research/ethics/' | url }}): consider whether answering your research questions would put participants in a compromising position. For example, studying the degree to which participants adhere to a law or policy enforced by the researcher’s own office or institution could jeopardize participants’ careers and/or pose authority and coercion issues. Take care when asking participants questions that might unintentionally exclude or harm interviewees. It’s your responsibility to make sure that a participant's experience in your research session is as smooth and painless as possible, particularly when asking about what isn’t working about a product/service or bringing up potentially sensitive emotional experiences. 
 
 - **Bad question:** How do we get unemployed adults interested in our website?
 (This question is bad because it isn’t directly focused on users and their goals; it also assumes that a website is the right solution for unemployed adults.)
@@ -181,7 +181,7 @@ We have a responsibility to further the best interests of the people impacted by
 - Mitigate the chances of triggering a trauma response by not recruiting people at their most vulnerable 
   - For example, if your project is to develop a person centered addiction recovery website, instead of someone actively experiencing addiction you might recruit people who are at least 30 days into their recovery journey or the friends and family of people expreincing addiction or in recovery 
 - Protect employee safety during internal research 
-  - We want stakeholders to be engaged, but having them observe usability tests and interviews of collegues might cause participants anxiety or diminished honesty in conversations about topics that might have potential repercussions to their jobs or relationships
+  - We want stakeholders to be engaged, but having them observe usability tests and interviews with colleagues might cause participants anxiety or diminished honesty in conversations about topics that might have potential repercussions to their jobs or relationships
 
 
 #### Recruitment for demographic diversity


### PR DESCRIPTION
## Changes proposed in this pull request:
From #541: A scan of the guides.18f.gov domain using Siteimprove resulted in [this list of misspellings](https://docs.google.com/spreadsheets/d/11WhzwV4hCdpm8qvj9rUDMc3VY2xvLxCtb_atrxvkJsQ/edit#gid=2014600603).

In addition to addressing the misspellings, this PR also adjusts several instances of repetitive/unclear language for better readability. _See the 'Notes' tab in the spreadsheet above for more detail on misspelling fixes vs. language updates._

## security considerations

None.
