### PR TITLE
Update Product guide owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,7 +30,7 @@
 # /content/design/**/*.md          @MelissaBraxton
 /content/eng-hiring/**/*.md      @amymok
 /content/engineering/**/*.md     @amymok
-/content/product/**/*.md         @allisonnorman
+/content/product/**/*.md         @lalitha-jonnalagadda
 /content/ux-guide/**/*.md        @bpdesigns
 
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- As per [this comment](https://github.com/18F/guides/issues/253#issuecomment-2121300141), Lalitha is now the Product guide owner. Updating CODEOWNERS to tag her appropriately in pull requests.

## Security considerations

None.
