### PR TITLE
Remove duplicate "More 18F guides" link from Agile guide menu

### DIFF
--- a/_data/navigation.yaml
+++ b/_data/navigation.yaml
@@ -8,8 +8,6 @@ accessibility:
 agile:
   - name: Home
     url: /agile/
-  - name: More 18F guides
-    url: https://18f.gsa.gov/guides/
 
 brand:
   - name: Introduction


### PR DESCRIPTION
Changes related to https://github.com/18F/guides/issues/568

## Changes proposed in this pull request:
- Removes duplicate "More 18F guides" link from Agile guide menu

## security considerations
N/A
