### PR TITLE
Create a new page for diagramming tools

### DIFF
--- a/content/engineering/tools/books-we-have-read.md
+++ b/content/engineering/tools/books-we-have-read.md
@@ -10,7 +10,7 @@ layout: layouts/page
 eleventyNavigation: 
   parent: engineering_tools
   key: Books we've read
-  order: 12
+  order: 13
   title: Books we've read
 ---
 

--- a/content/engineering/tools/continuous-deployment.md
+++ b/content/engineering/tools/continuous-deployment.md
@@ -10,7 +10,7 @@ layout: layouts/page
 eleventyNavigation:
   parent: engineering_tools
   key: Continuous deployment
-  order: 8
+  order: 9
   title: Continuous deployment
 subnav:
   - text: Pre-requisites

--- a/content/engineering/tools/datastore-selection.md
+++ b/content/engineering/tools/datastore-selection.md
@@ -10,7 +10,7 @@ layout: layouts/page
 eleventyNavigation: 
   parent: engineering_tools
   key: Datastore selection
-  order: 9
+  order: 10
   title: Datastore selection
 subnav:
   - text: Our use case

--- a/content/engineering/tools/diagramming.md
+++ b/content/engineering/tools/diagramming.md
@@ -45,7 +45,7 @@ Diagrams are typically rendered to an image file, like png.
 
 [PlantUML](https://plantuml.com/) is the heavy lifter in our diagramming toolbox. In spite of "UML" in the name, it renders many types of diagrams. It requires a Java runtime (and sometimes Graphviz) to generate diagrams. Diagram code is written in PlantUML's own DSL. Cloud.gov does some of [their diagrams](https://diagrams.fr.cloud.gov/) using it; the source code is in their [diagram repository](https://github.com/cloud-gov/cg-diagrams).
 
-The [PlantUML standard library](https://github.com/plantuml-stdlib/C4-PlantUML) supports [the C4 Model for representing system architecture](https://c4model.com/) well. You can see [examples of C4 PlantUML](https://github.com/GSA/datagov-compliance) for data.gov.
+The [PlantUML standard library](https://github.com/plantuml-stdlib/C4-PlantUML) supports [the C4 Model for representing system architecture](https://c4model.com/) well. For examples, see [data.gov's diagrams](https://github.com/GSA/datagov-compliance) or [Tock's diagrams](https://github.com/18F/tock/tree/main/docs/diagrams).
 
 The TTS [rails-template](https://github.com/18F/rails-template/tree/main/templates/doc/compliance) comes with instructions for using PlantUML to help with the ATO (authority to operate) process.
 

--- a/content/engineering/tools/diagramming.md
+++ b/content/engineering/tools/diagramming.md
@@ -1,0 +1,71 @@
+---
+title: Diagramming
+sidenav: true
+sticky_sidenav: true
+permalink: /engineering/tools/diagramming/
+redirect_from:
+  - engineering/diagramming/
+tags: engineering
+layout: layouts/page
+eleventyNavigation:
+  parent: engineering_tools
+  key: Diagramming
+  order: 8
+  title: Diagramming
+---
+
+Diagrams are helpful for making sense of complex systems and may be requested or required by an agency partner as part of their security and compliance process. They can also just be fun!
+
+While the diagramming tools chosen for each TTS project varies, a good tool will:
+
+- produce clear, readable diagrams
+- not share sensitive data with any unauthorized person
+- be easy to use so that diagrams are maintained
+- produce a diagram that can be updated without needing access to additional systems or software
+
+## Accessibility
+
+Make sure that all the information you put into a diagram is also available in text, preferably on the same page or in the same document. It's a nice thing to do and it is also the law.
+
+Also, some people can't see colors or contrast very well, so avoid small fonts, smudgy greys, tiny dots, and if you use color to convey meaning, include the same information with shapes or text.
+
+## Mermaid
+
+[Mermaid](https://mermaid.js.org/intro/) is a JavaScript library for diagram rendering. Diagram code is written in Mermaid's own DSL (domain specific language). Cloud.gov does some of [their diagrams](diagrams.fr.cloud.gov) using it; the source code is in their [diagram repository](https://github.com/cloud-gov/cg-diagrams).
+
+It also has [inline rendering support from GitHub](https://github.blog/2022-02-14-include-diagrams-markdown-files-mermaid/) which makes it a good choice if you'd like to include diagrams as code directly in a markdown file to be viewed on GitHub's website.
+
+## Graphviz
+
+[Graphviz](https://graphviz.org/) is software program for diagram rendering. It runs on Windows, Mac, and Linux. Diagram code is written in DOT language, which is Graphviz's own DSL. Other tools are able to output DOT files, such as how this GSA Touchpoints [data model](https://github.com/GSA/touchpoints/wiki/Data-Model) was generated, and some editors like [Edotor](https://edotor.net/) exist to help you visualize how a piece of syntax works.
+
+Diagrams are typically rendered to an image file, like png.
+
+## PlantUML (PUML)
+
+[PlantUML](https://plantuml.com/) is the heavy lifter in our diagramming toolbox. In spite of "UML" in the name, it renders many types of diagrams. It requires a Java runtime (and sometimes Graphviz) to generate diagrams. Diagram code is written in PlantUML's own DSL. Cloud.gov does some of [their diagrams](diagrams.fr.cloud.gov) using it; the source code is in their [diagram repository](https://github.com/cloud-gov/cg-diagrams).
+
+The [PlantUML standard library](https://github.com/plantuml-stdlib/C4-PlantUML) supports [the C4 Model for representing system architecture](https://c4model.com/) well. You can see [examples of C4 PlantUML](https://github.com/GSA/datagov-compliance) for data.gov.
+
+The TTS [rails-template](https://github.com/18F/rails-template/tree/main/templates/doc/compliance) comes with instructions for using PlantUML to help with the ATO (authority to operate) process.
+
+In the case of maintaining a large number of diagrams which need to be updated frequently, some teams may opt to host a PlantUML server to render the images on the fly. This saves having to manually regenerate images each time the diagrams change.
+
+{% include "engineering/tag-caution.html" %} PlantUML's default configuration uses their own server, which is almost certainly not what you want. Run PlantUML locally or self-host.
+
+## An example of using a diagram in HTML
+
+This example is taken from the <a href="{{'/engineering/tools/sharepoint/' | url }}">SharePoint primer</a>.
+
+```html
+<figure>
+  <img src="..." alt="Diagram of ..." />
+  <figcaption>
+    <details>
+      <summary>Source for diagram</summary>
+      ... how the diagram is generated...
+      ... code for the diagram...
+    </details>
+  </figcaption>
+</figure>
+```

--- a/content/engineering/tools/diagramming.md
+++ b/content/engineering/tools/diagramming.md
@@ -31,7 +31,7 @@ Also, some people can't see colors or contrast very well, so avoid small fonts, 
 
 ## Mermaid
 
-[Mermaid](https://mermaid.js.org/intro/) is a JavaScript library for diagram rendering. Diagram code is written in Mermaid's own DSL (domain specific language). Cloud.gov does some of [their diagrams](diagrams.fr.cloud.gov) using it; the source code is in their [diagram repository](https://github.com/cloud-gov/cg-diagrams).
+[Mermaid](https://mermaid.js.org/intro/) is a JavaScript library for diagram rendering. Diagram code is written in Mermaid's own DSL (domain specific language). Cloud.gov does some of [their diagrams](https://diagrams.fr.cloud.gov/) using it; the source code is in their [diagram repository](https://github.com/cloud-gov/cg-diagrams).
 
 It also has [inline rendering support from GitHub](https://github.blog/2022-02-14-include-diagrams-markdown-files-mermaid/) which makes it a good choice if you'd like to include diagrams as code directly in a markdown file to be viewed on GitHub's website.
 
@@ -43,7 +43,7 @@ Diagrams are typically rendered to an image file, like png.
 
 ## PlantUML (PUML)
 
-[PlantUML](https://plantuml.com/) is the heavy lifter in our diagramming toolbox. In spite of "UML" in the name, it renders many types of diagrams. It requires a Java runtime (and sometimes Graphviz) to generate diagrams. Diagram code is written in PlantUML's own DSL. Cloud.gov does some of [their diagrams](diagrams.fr.cloud.gov) using it; the source code is in their [diagram repository](https://github.com/cloud-gov/cg-diagrams).
+[PlantUML](https://plantuml.com/) is the heavy lifter in our diagramming toolbox. In spite of "UML" in the name, it renders many types of diagrams. It requires a Java runtime (and sometimes Graphviz) to generate diagrams. Diagram code is written in PlantUML's own DSL. Cloud.gov does some of [their diagrams](https://diagrams.fr.cloud.gov/) using it; the source code is in their [diagram repository](https://github.com/cloud-gov/cg-diagrams).
 
 The [PlantUML standard library](https://github.com/plantuml-stdlib/C4-PlantUML) supports [the C4 Model for representing system architecture](https://c4model.com/) well. You can see [examples of C4 PlantUML](https://github.com/GSA/datagov-compliance) for data.gov.
 

--- a/content/engineering/tools/sharepoint.md
+++ b/content/engineering/tools/sharepoint.md
@@ -10,7 +10,7 @@ layout: layouts/page
 eleventyNavigation: 
   parent: engineering_tools
   key: SharePoint primer
-  order: 11
+  order: 12
   title: SharePoint primer
 subnav:
   - text: SharePoint presentation methods

--- a/content/engineering/tools/web-architecture.md
+++ b/content/engineering/tools/web-architecture.md
@@ -10,7 +10,7 @@ layout: layouts/page
 eleventyNavigation:
   parent: engineering_tools
   key: Choosing a web app architecture
-  order: 10
+  order: 11
   title: Choosing a web app architecture
 subnav:
   - text: Why push for simplicity


### PR DESCRIPTION
## Changes proposed in this pull request:

- #327 
    - Creates a new page to suggest PlantUML, Mermaid, and Graphviz with links to examples and documentation.

## security considerations

None, this is a content-only change
