### PR TITLE
Updating CODEOWNERS and CONTRIBUTING files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,9 +25,9 @@
 /content/brand/**/*.md           @igorkorenfeld
 /content/content-guide/**/*.md   @michelle-rago
 /content/derisking/**/*.md       @adunkman
-/content/methods/**/*.md          @MelissaBraxton
-/content/eng-hiring/**/*.md      @amymok
-/content/engineering/**/*.md     @amymok
+/content/methods/**/*.md         @MelissaBraxton
+/content/eng-hiring/**/*.md      @hbillings
+/content/engineering/**/*.md     @hbillings
 /content/product/**/*.md         @lalitha-jonnalagadda
 /content/ux-guide/**/*.md        @bpdesigns
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 We're so glad you're thinking about contributing to a [open source project of the U.S. government](https://code.gov/)! If you're unsure about anything, just ask -- or submit the issue or pull request anyway. The worst that can happen is you'll be politely asked to change something. We love all friendly contributions.
 
-We encourage you to read this project's CONTRIBUTING policy (you are here), its [LICENSE](LICENSE.md), and its [README](README.md).
+We encourage you to read this project's CONTRIBUTING policy (you are here), its [LICENSE](LICENSE.md), and its [README](README.md). The [CODEOWNERS file](.github/CODEOWNERS) defines the approvals that are required to update the code and content of the guides within this project.
 
 ## Policies
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Changes CODEOWNERS file ownership from Amy to Heather for `engineering` and `eng-hiring` guides
- Adds a line to the CONTRIBUTING file that explains the existence and purpose of CODEOWNERS

Note that the CODEOWNERS file is showing an error around Heather's repo access, but I have confirmed she is part of the 18F org and should have access. 

## security considerations
N/A
