### PR TITLE
Add UX research screener template

### DIFF
--- a/content/ux-guide/resources.md
+++ b/content/ux-guide/resources.md
@@ -38,6 +38,9 @@ Prompts for planning research. Pairs well with our [research planning]({{ '/ux-g
 [Usability test quality heuristics]({{ '/ux-guide/usability-test-quality-heuristics/' | url }}). ([Google Docs usability test quality heuristics](https://docs.google.com/document/d/1qfGp3H1pdOlNbMYuJNQGyBIkpOcQErduDAl0adv1X-w/edit)).  
 A list of indicators to help you and your team determine if your usability test will produce useful results.
 
+[Recruiting screener]({{ '/ux-guide/resources/recruiting-screener/' | url }}).  
+An example form to find research participants in your target audiences.
+
 ### Privacy and informed consent
 18F’s Design Research is covered by [GSA's Privacy Act Statement for Design Research.](https://www.gsa.gov/reference/gsa-privacy-program/privacy-act-statement-for-design-research)
 

--- a/content/ux-guide/resources/recruiting-screener.md
+++ b/content/ux-guide/resources/recruiting-screener.md
@@ -1,6 +1,6 @@
 ---
 title: Recruiting screener [template]
-description: An example form for finding research participants in your target audience
+description: An example form to find research participants in your target audiences
 permalink: /ux-guide/resources/recruiting-screener/
 layout: layouts/page
 tags: ux-guide

--- a/content/ux-guide/resources/recruiting-screener.md
+++ b/content/ux-guide/resources/recruiting-screener.md
@@ -5,8 +5,8 @@ permalink: /ux-guide/resources/recruiting-screener/
 layout: layouts/page
 tags: ux-guide
 eleventyNavigation: 
-  parent: 
-  key: 
+  parent: Resources
+  key: Recruiting screener
   order: 1
   title: Recruiting screener
 sidenav: true

--- a/content/ux-guide/resources/recruiting-screener.md
+++ b/content/ux-guide/resources/recruiting-screener.md
@@ -1,0 +1,89 @@
+---
+title: Recruiting screener [template]
+description: An example form for finding research participants in your target audience
+permalink: /ux-guide/resources/recruiting-screener/
+layout: layouts/page
+tags: ux-guide
+eleventyNavigation: 
+  parent: 
+  key: 
+  order: 1
+  title: Recruiting screener
+sidenav: true
+sticky_sidenav: true
+subnav:
+  - text: Standard questions
+    href: "#standard-questions"
+  - text: Questions to avoid unless necessary
+    href: "#avoid"
+---
+
+## Participate in research for `[Example.gov]`
+
+We’re looking for people to provide honest feedback to improve `[Example.gov]`. Complete this form if you’d like to participate in the research.
+
+- You don’t need to be a U.S. citizen or speak English to participate.  
+- If you participate in a session, you will receive `[a $75 gift card as compensation]`.  
+- This is completely voluntary and you can end your participation at any time.
+
+We’ll ask you questions about your experiences with `[Example.gov]`. We’ll share a link to a new version of the site that you can open on a computer or mobile device. We will ask you to screenshare with us so we can follow along as you navigate the site.
+
+### Standard questions
+
+1. What is the best way to contact you?
+- Email
+- Phone
+- Text
+
+2. Do you have regular access to the internet?
+
+3. How did you hear about this effort?
+
+4. `[Program or agency-related questions, such as how often the participant visits the website or which kinds of information they typically use.]`
+
+5. Do you use assistive technology when accessing the internet?
+
+6. Do you need any accommodations to participate in the session?
+- Captioning
+- Sign language interpreter
+- Large print
+- Breaks for thinking and processing
+- No flashing or flickering images
+- Ramp or wheelchair access `[for in-person sessions]`
+- Other (please specify):
+
+7. Are you available during any of these times on `[Monday,September 28]`? Check all that apply:
+- `H:MM am or pm ET (H:MM am or pm PT)`
+- `H:MM am or pm ET (H:MM am or pm PT)`
+- `H:MM am or pm ET (H:MM am or pm PT)`
+
+8. Are you available during any of these times on `[Tuesday,September 29]`? Check all that apply:
+- `H:MM am or pm ET (H:MM am or pm PT)`
+- `H:MM am or pm ET (H:MM am or pm PT)`
+- `H:MM am or pm ET (H:MM am or pm PT)`
+
+9. Is there anything you’d like us to know when contacting you?
+
+### Questions to avoid unless necessary for the research goals
+
+1. Voluntary questions about your background. In an effort to make sure `[product/service]` is inclusive, accessible, and easy to use for those who have `[faced historical or other barriers to accessing this product/service]`. Please let us know if you identify as any of the following. This is voluntary; please only share the information you feel comfortable sharing.
+
+2. Ethnicity and race. We are trying to better understand how ethnicity and race impact access to `[product/service]`. Please share your ethnicity or race if you feel comfortable doing so.
+
+3. What cultures or ethnicities do you identify with? There are no incorrect answers. Example answers: Black American, Eastern European, Hindu and Vietnamese, Taíno, Uchinanchu, Nigerian, Navajo, etc.
+
+4. Do you identify as Hispanic or Latino? Select one:
+- Yes
+- No
+- Prefer not to answer
+
+5. Race (select all that apply):
+- American Indian or Alaska Native
+- Asian
+- Black or African American
+- Middle Eastern or North African
+- Native Hawaiian or other Pacific Islander
+- White
+- Prefer not to answer
+
+_Note that these race and ethnicity categories are derived from the Office of Management and Budget’s [guidelines pertaining to demographic questions](https://www.whitehouse.gov/omb/briefing-room/2024/03/28/omb-publishes-revisions-to-statistical-policy-directive-no-15-standards-for-maintaining-collecting-and-presenting-federal-data-on-race-and-ethnicity/)._

--- a/content/ux-guide/resources/recruiting-screener.md
+++ b/content/ux-guide/resources/recruiting-screener.md
@@ -7,7 +7,7 @@ tags: ux-guide
 eleventyNavigation: 
   parent: Resources
   key: Recruiting screener
-  order: 1
+  order: 3
   title: Recruiting screener
 sidenav: true
 sticky_sidenav: true

--- a/content/ux-guide/resources/recruiting-screener.md
+++ b/content/ux-guide/resources/recruiting-screener.md
@@ -14,8 +14,8 @@ sticky_sidenav: true
 subnav:
   - text: Standard questions
     href: "#standard-questions"
-  - text: Questions to avoid unless necessary
-    href: "#avoid"
+  - text: Questions to avoid unless necessary for the research goals
+    href: "#questions-to-avoid"
 ---
 
 ## Participate in research for `[Example.gov]`


### PR DESCRIPTION
## Changes proposed in this pull request

- Add research screener to provide sample language for accommodations as well as broader topics (e.g., contact info, contact preferences, voluntary questions about race and ethnicity)
- Add link to screener template to main resources page
- Fixes #576 

## Review notes

- I am new to 11ty and this era of 18F, am not sure if I did the markdown correctly for the navigation and metadata. Please check that for me.
- Additional links to this will be included in a future pull request for #304.
- No security concerns that I am aware of.