### PR TITLE
Reduced line-height on .method--title (#420)

### DIFF
--- a/assets/methods/styles/_method.scss
+++ b/assets/methods/styles/_method.scss
@@ -44,8 +44,10 @@
   border-top: 8px solid;
   font-size: font-size('heading',xl);
   font-weight: font-weight('bold');
+  line-height: line-height('heading', 3);
   margin-top: units(2);
   padding-top: units(3);
+  
 }
 
 .method--title a,


### PR DESCRIPTION
## Changes proposed in this pull request:

This is a proposed fix for #420, to close up the leading on `.method-title` elements.

Here's the default/current treatment of the element:

![Opening of a method page titled "Stakeholder and user interviews". The first subsection, titled "What:", reads, "A wide-spanning set of semi-structured interviews with living experts who have an interest in a project’s success, including stakeholders and users." The page's title has too much space between the lines.](https://github.com/18F/guides/assets/170676235/89e2a7b7-26e9-4773-bd40-2b0eaced7dc2)

Here's the updated treatment, once the below fix is applied:

![An updated screenshot of the same method page titled "Stakeholder and user interviews". The page's title has less space between the lines, demonstrating the updated CSS.](https://github.com/18F/guides/assets/170676235/24be079e-6011-4266-9430-a3c5dab96ed7)

## security considerations

No security considerations AFAIK; this is a CSS-only change.