### PR TITLE
Removed links to the PDFs but kept the footnotes.

### DIFF
--- a/content/derisking/federal-field-guide/1-introduction.md
+++ b/content/derisking/federal-field-guide/1-introduction.md
@@ -49,4 +49,4 @@ Some portions of this handbook were written specifically as part of this broader
 **Next**: [Basic principles of modern software design]({{ "/derisking/federal-field-guide/basic-principles/" | url }})
 
 ### Footnotes
-[^successful]: Projects valued at $6M or greater, in Europe and the United States, that were completed satisfactorily, on time, and within budget. From The Standish Group’s "<a href="https://www.standishgroup.com/sample_research_files/Haze4.pdf">Haze</a>," based on their CHAOS database.
+[^successful]: Projects valued at $6M or greater, in Europe and the United States, that were completed satisfactorily, on time, and within budget. From The Standish Group based on their CHAOS database.

--- a/content/derisking/state-field-guide/1-introduction.md
+++ b/content/derisking/state-field-guide/1-introduction.md
@@ -47,6 +47,6 @@ As government leaders, we must be good stewards of public money by demanding eas
 **Next**: [Basic principles of modern software design]({{ "/derisking/state-field-guide/basic-principles/" | url }})
 
 ### Footnotes
-[^13pct]: Projects valued at $6M or greater, in Europe and the United States, that were completed satisfactorily, on time, and within budget. From The Standish Group’s "<a href="https://www.standishgroup.com/sample_research_files/Haze4.pdf">Haze</a>," based on their CHAOS database.
+[^13pct]: Projects valued at $6M or greater, in Europe and the United States, that were completed satisfactorily, on time, and within budget. From The Standish Group based on their CHAOS database.
 
 [^ineffective]: Of the $90 billion in federal IT spending in FY2019, 80% is allocated for maintenance of legacy software, according to the GAO’s June 2019 report, "<a href="https://www.gao.gov/products/GAO-19-471">Agencies Need to Develop Modernization Plans for Critical Legacy Systems</a>." They write that inadequately-maintained legacy software leads to security risks, unmet mission needs, staffing issues, and increased costs.

--- a/content/derisking/state-field-guide/3-budgeting-tech.md
+++ b/content/derisking/state-field-guide/3-budgeting-tech.md
@@ -384,9 +384,9 @@ It is no kindness to fund a project that is going to fail. If the agency doesn�
 
 [^etc]: For more about the difference between O&amp;M and continuous agile development, read <a href="https://18f.gsa.gov/2016/02/23/software-maintenance-is-an-anti-pattern/">"Software maintenance is an anti-pattern"</a> on the 18F blog.
 
-[^project]: In The Standish Group’s 2014 CHAOS Report, based on a survey of 25,000 software projects, they found that <a href="https://www.standishgroup.com/sample_research_files/CHAOSReport2014.pdf#page=3">software projects that cost more than $10 million succeed only 8% of the time</a>. Outcomes improve substantially as the dollar value is reduced, peaking at a 70% success rate for projects under $1 million.
+[^project]: In The Standish Group’s 2014 CHAOS Report, based on a survey of 25,000 software projects, they found that software projects that cost more than $10 million succeed only 8% of the time. Outcomes improve substantially as the dollar value is reduced, peaking at a 70% success rate for projects under $1 million.
 
-[^markedly]: In The Standish Group’s 2014 CHAOS Report, based on a survey of 25,000 software projects, they found that <a href="https://www.standishgroup.com/sample_research_files/CHAOSReport2014.pdf#page=3">software projects’ outcomes get worse as more money is spent</a>. Limiting the spending on each contract segments the project into smaller components, making each component — and the entire project — more likely to succeed.
+[^markedly]: In The Standish Group’s 2014 CHAOS Report, based on a survey of 25,000 software projects, they found that software projects’ outcomes get worse as more money is spent. Limiting the spending on each contract segments the project into smaller components, making each component — and the entire project — more likely to succeed.
 
 [^state]: Alaska’s Department of Health &amp; Social Services faced this challenge in 2017, and their Contracts and Procurement Manager wrote about the process that they used to attract small, agile, Alaskan vendors in "<a href="https://18f.gsa.gov/2017/09/12/how-alaska-is-using-transparency/">How Alaska is using transparency to attract modern software vendors</a>."
 


### PR DESCRIPTION
## Changes proposed in this pull request:
From #559 Decide to remove links to external PDFs that trigger a 403 error
- Removed the links to the offending PDFs but kept the footnotes.

## security considerations

- This removes links that violate the GSA IT General Rules of Behavior
![Screenshot 2024-06-14 at 10 26 04 AM](https://github.com/18F/guides/assets/106776019/6971c08a-5a9e-4b75-9115-fa1969da6d4d)

