### PR TITLE
Create equity-pause.md

### DIFF
--- a/content/methods/discover/equity-pause.md
+++ b/content/methods/discover/equity-pause.md
@@ -1,0 +1,51 @@
+---
+title: Equity pause
+description: A conversation guide to uncover ethical issues that may show up in your work.
+permalink: /methods/discover/equity-pause/
+redirect_from:
+  - equity-pause/
+layout: layouts/method-card
+tags: methods
+eleventyNavigation:
+  key: methods
+  parent: Discover
+  title: Equity pause
+method:
+  title: Equity pause
+  what: A conversation guide to uncover ethical issues that may show up in your work.
+  why: High-pressure projects and tight timelines can mask biases that aren’t being addressed. An equity pause allows you to notice, voice, and challenge those biases.
+  timeRequired: 1-2 hours, ongoing
+  category: discover
+---
+
+## How to do it{#how-equity}
+
+  1. <b>Make time for it.</b> This can be an individual reflection or team conversation.
+  1. <b>Create a safe space.</b> This includes keeping the conversation private, focusing on understanding others rather than being understood, and accepting the conversation may not offer closure.
+  1. <b>Identify an outside facilitator.</b> This role helps your team focus on the discussion. The facilitator is also responsible for maintaining a safe space for discussion. This includes things like ensuring people’s opinions are respected, everyone has an equal chance to speak, and that the conversation remains confidential.
+  1. <b>Some prompts for discussion:</b>
+     - How might our project goals create or perpetuate harm?
+     - What power dynamics might be influencing our work?
+     - Who are we not hearing from? Why?
+     - What are our biases?
+     - Are we acknowledging the history of the government and tech industry’s role in this space?
+     - Are we building relationships with our partners? Our users? Each other?
+     - How might we make our processes more inclusive?
+     - What would we like to say that hasn't been said?
+  
+
+<section class="method--section method--section--additional-resources" markdown="1">
+
+## Additional resources{#add-equity}
+
+- [Ethics and roles](https://guides.18f.gov/ux-guide/research/ethics/), 18F User Experience Guide
+- [Power dynamics in research](https://guides.18f.gov/ux-guide/research/share-power/), 18F User Experience Guide
+
+</section>
+
+<section class="method--section method--section--government-considerations" markdown="1" >
+
+## Considerations for use in government{#con-equity}
+
+Equity pauses are important to do as government employees. This is because of the U.S. government’s history of creating and perpetuating oppression. Without reflection and action, we can unintentionally favor some people over others.
+</section>


### PR DESCRIPTION
Creating a new method card in the "discover" section for equity pauses. It's in "discover" rather than "fundamentals" because it's more actionable than the other fundamental content.

(I also don't want to add any more fundamental content until we create a clearer content strategy for that section.)

## Changes proposed in this pull request:

- Adding a new method card

## security considerations

None