### PR TITLE
Remove link to GSA slide gallery

### DIFF
--- a/content/brand/templates.md
+++ b/content/brand/templates.md
@@ -35,8 +35,6 @@ We have three Google Docs templates: a [basic outline](https://docs.google.com/a
 ## Google Slides presentation templates
 {% image_with_class "assets/brand/img/18F-slide-theme-cover.svg" "" "18F slide template cover" %}
 
-[GSA slide template gallery](https://docs.google.com/presentation/u/0/?ftv=1&folder=0BwWYNZcEDfwabE13dnZpbFN5QmM&tgif=d){.usa-button}
-
 ### Instructions
 #### To make a new Google Slides presentation
 1. In Google Drive, click **New > Google Slides > From a template**.


### PR DESCRIPTION
## Changes proposed in this pull request
This PR removes the button link to the GSA slide gallery from the Brand guide's templates page. @claireb-gsa discovered that any presentation created using the 18F template after clicking on this link was placed in the 18F template presentations folder. This creates a lot of files with the duplicate title "18F Slide Theme" which make it difficult to tell which file is actually the theme file and which are copies, and generally leads to a more cluttered folder.  

👓 [Preview](https://federalist-8bc0b42c-5fd0-4ae8-9366-cd9c265a4446.sites.pages.cloud.gov/preview/18f/guides/ik/remove-slide-gallery-button/brand/templates/)
