### PR TITLE
Add alert banner and redirects from v1 of DRG to v2

### DIFF
--- a/_includes/derisking/redirect_url.html
+++ b/_includes/derisking/redirect_url.html
@@ -2,7 +2,7 @@
   <div class="usa-alert__body">
     <p class="usa-alert__text">
       There's a new version of this guide!
-      <a class="usa-link" href="{{ redirect-url | url }}">Check out De-risking Government Technology Guide 2.0
+      <a class="usa-link" href="{{ redirect-url | url }}">Check out De-risking Government Technology Guide 2.0</a>
     </p>
   </div>
 </div>

--- a/_includes/derisking/redirect_url.html
+++ b/_includes/derisking/redirect_url.html
@@ -1,0 +1,8 @@
+<div class="usa-alert usa-alert--emergency margin-0" role="alert">
+  <div class="usa-alert__body">
+    <p class="usa-alert__text">
+      There's a new version of this guide!
+      <a class="usa-link" href={{redirect-url}}>Check out De-risking Government Technology Guide 2.0
+    </p>
+  </div>
+</div>

--- a/_includes/derisking/redirect_url.html
+++ b/_includes/derisking/redirect_url.html
@@ -2,7 +2,7 @@
   <div class="usa-alert__body">
     <p class="usa-alert__text">
       There's a new version of this guide!
-      <a class="usa-link" href={{redirect-url}}>Check out De-risking Government Technology Guide 2.0
+      <a class="usa-link" href="{{ redirect-url | url }}">Check out De-risking Government Technology Guide 2.0
     </p>
   </div>
 </div>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -65,4 +65,10 @@ official government website
     </div>
   </div>
   <div class="usa-overlay"></div>
+{% comment %}
+This is a temporary include to render redirects from the original de-risking guide to version 2
+{% endcomment %}
+  {% if tags[0] == 'derisking' and redirect-url %}
+    {% include 'derisking/redirect_url.html' %}
+  {% endif %}
 </div>

--- a/content/derisking/federal-field-guide/1-introduction.md
+++ b/content/derisking/federal-field-guide/1-introduction.md
@@ -2,6 +2,7 @@
 layout: layouts/page
 title: Federal Field Guide
 tags: derisking
+redirect-url: https://guides.18f.gov/derisking-government-tech/
 description: Guidance for federal agencies about how to procure, customize, or build user-centered software while reducing risk of wasteful spending.
 permalink: /derisking/federal-field-guide/
 eleventyNavigation:

--- a/content/derisking/federal-field-guide/1-introduction.md
+++ b/content/derisking/federal-field-guide/1-introduction.md
@@ -2,7 +2,7 @@
 layout: layouts/page
 title: Federal Field Guide
 tags: derisking
-redirect-url: https://guides.18f.gov/derisking-government-tech/
+redirect-url: /derisking-government-tech/
 description: Guidance for federal agencies about how to procure, customize, or build user-centered software while reducing risk of wasteful spending.
 permalink: /derisking/federal-field-guide/
 eleventyNavigation:

--- a/content/derisking/federal-field-guide/2-basic-principles.md
+++ b/content/derisking/federal-field-guide/2-basic-principles.md
@@ -4,6 +4,7 @@ title: Basic principles of modern software design
 page_title_tag: h2
 hidden_guide_title: Federal Field Guide
 tags: derisking
+redirect-url: /derisking-government-tech/principles/
 description: Introduction for federal employees to user-centered design, agile software development, DevOps, loosely coupled parts, modular contracting and product ownership.
 permalink: /derisking/federal-field-guide/basic-principles/
 eleventyNavigation:

--- a/content/derisking/federal-field-guide/3-planning.md
+++ b/content/derisking/federal-field-guide/3-planning.md
@@ -4,6 +4,7 @@ title: Planning
 page_title_tag: h2
 hidden_guide_title: Federal Field Guide
 tags: derisking
+redirect-url: /derisking-government-tech/principles/
 description: How to reduce risk when planning software projects by empowering a product owner, doing user research, picking open source and scoping work tightly.
 permalink: /derisking/federal-field-guide/planning/
 eleventyNavigation:

--- a/content/derisking/federal-field-guide/4-deciding-what-to-buy.md
+++ b/content/derisking/federal-field-guide/4-deciding-what-to-buy.md
@@ -4,6 +4,7 @@ title: Deciding what to buy
 page_title_tag: h2
 hidden_guide_title: Federal Field Guide
 tags: derisking
+redirect-url: /derisking-government-tech/software-solutions/
 description: How to reduce risk when buying custom software during the research and solicitation phases of acquisition.
 permalink: /derisking/federal-field-guide/deciding-what-to-buy/
 eleventyNavigation:

--- a/content/derisking/federal-field-guide/5-doing-the-work.md
+++ b/content/derisking/federal-field-guide/5-doing-the-work.md
@@ -4,6 +4,7 @@ title: Doing the work
 page_title_tag: h2
 hidden_guide_title: Federal Field Guide
 tags: derisking
+redirect-url: /derisking-government-tech/vendor-management/
 description: Vendor management best practices for software projects, from kick-off through measuring performance with a Quality Assurance Surveillance Plan (QASP). 
 permalink: /derisking/federal-field-guide/doing-the-work/
 eleventyNavigation:

--- a/content/derisking/federal-field-guide/6-appendix.md
+++ b/content/derisking/federal-field-guide/6-appendix.md
@@ -4,6 +4,7 @@ title: Appendix
 page_title_tag: h2
 hidden_guide_title: Federal Field Guide
 tags: derisking
+redirect-url: /derisking-government-tech/resources/
 description: Ask a vendor competing for a custom software project these questions during verbal interviews to clarify their technical approach.
 permalink: /derisking/federal-field-guide/appendix/
 eleventyNavigation:

--- a/content/derisking/index.html
+++ b/content/derisking/index.html
@@ -3,6 +3,7 @@ title: De-risking government technology
 permalink: /derisking/
 layout: layouts/default
 tags: derisking
+redirect-url: /derisking-government-tech/
 description: Expert guidance for federal and state agencies for buying or building user-centered software, from planning through managing a contract and vendor.
 eleventyNavigation:
   key: derisking-home-index

--- a/content/derisking/qasp.md
+++ b/content/derisking/qasp.md
@@ -5,6 +5,7 @@ redirect_from:
   - derisking/state-field-guide/qasp/
 layout: layouts/page
 tags: derisking
+redirect-url: /derisking-government-tech/resources/
 description: Sample Quality Assurance Surveillance Plan (QASP), a vendor management tool for tracking, evaluating, and correcting performance.
 ---
 

--- a/content/derisking/state-field-guide/1-introduction.md
+++ b/content/derisking/state-field-guide/1-introduction.md
@@ -1,6 +1,7 @@
 ---
 title: State Software Budgeting Handbook
 tags: derisking
+redirect-url: /derisking-government-tech/
 description: Guidance for state agencies about how to procure, customize, or build user-centered software while reducing risk of wasteful spending.
 permalink: /derisking/state-field-guide/
 layout: layouts/page

--- a/content/derisking/state-field-guide/2-basic-principles.md
+++ b/content/derisking/state-field-guide/2-basic-principles.md
@@ -3,6 +3,7 @@ title: Basic principles of modern software design
 page_title_tag: h2
 hidden_guide_title: State Software Budgeting Handbook
 tags: derisking
+redirect-url: /derisking-government-tech/principles/
 description: Introduction for state employees to user-centered design, agile software development, DevOps, loosely coupled parts, modular contracting and product ownership.
 permalink: /derisking/state-field-guide/basic-principles/
 layout: layouts/page

--- a/content/derisking/state-field-guide/3-budgeting-tech.md
+++ b/content/derisking/state-field-guide/3-budgeting-tech.md
@@ -4,6 +4,7 @@ page_title_tag: h2
 hidden_guide_title: State Software Budgeting Handbook
 seo_title: Budgeting and overseeing state-level tech projects
 tags: derisking
+redirect-url: /derisking-government-tech/principles/
 description: Guidance for state agencies for budgeting and managing software projects, including tools for recognizing progress and warning signs.
 permalink: /derisking/state-field-guide/budgeting-tech/
 layout: layouts/page

--- a/content/derisking/state-field-guide/4-questions-to-ask.md
+++ b/content/derisking/state-field-guide/4-questions-to-ask.md
@@ -3,6 +3,7 @@ title: Questions to ask
 page_title_tag: h2
 hidden_guide_title: State Software Budgeting Handbook
 tags: derisking
+redirect-url: /derisking-government-tech/resources/
 description: Questions for evaluating if a government custom software project is being set up to serve user needs and manage vendor performance effectively.
 permalink: /derisking/state-field-guide/questions-to-ask/
 layout: layouts/page


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adds notification bar and conditional logic to render it on /derisking pages with a 'redirect-url' variable
- adds redirect-urls to pages in the original guide that point to corresponding pages in the new guide
- https://github.com/18F/TLC-crew/issues/917

## security considerations

None
