### PR TITLE
adds robots.txt per search.gov recs

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -27,6 +27,9 @@ module.exports = function (config) {
   // Copy the `admin` folders to the output
   config.addPassthroughCopy('admin');
 
+  // Copy the robots.txt file to the output
+  config.addPassthroughCopy('robots.txt');
+
   // Copy USWDS init JS so we can load it in HEAD to prevent banner flashing
   config.addPassthroughCopy({'./node_modules/@uswds/uswds/dist/js/uswds-init.js': 'assets/js/uswds-init.js'});
 

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,9 @@
+Sitemap: https://guides.18f.gov/sitemap.xml
+
+User-agent: usasearch
+Allow: /
+Crawl-delay: 2
+
+User-agent: *
+Allow: /
+Crawl-delay: 10


### PR DESCRIPTION
Closes #243 

## Changes proposed in this pull request:

- adds a robots.txt file to the guides repo
- allows all robots, specifies that search.gov can index a page every 2 seconds

Questions:

- are there any agents that we want to address specifically?
- are there any pages that we don't want crawled?

## security considerations

No concerns.