### PR TITLE
Remove `twitter:title` meta tag

### DIFF
--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -38,7 +38,6 @@
 
   <meta name="twitter:card" content="summary" />
   <meta name="twitter:site" content="@{{site.twitter}}" />
-  <meta name="twitter:title" content="{{title}}" />
   <meta name="twitter:description" content="{{description}}" />
 
   <meta property="og:type" content="article" />


### PR DESCRIPTION
## Changes proposed in this pull request:

Per discussion with @ameliaswong, we'd like X/Twitter cards for Guides pages to display the full page title, with " | 18F <guide title>" appended.

For example: currently an X card for https://guides.18f.gov/methods/decide/service-blueprint/ shows the title as "Service blueprint", rather than "Service blueprint | 18F Methods".

This PR removes the `twitter:title` meta tag from Guides pages. Per X [developer documentation](https://developer.x.com/en/docs/x-for-websites/cards/guides/getting-started#opengraph): "When the Twitter card processor looks for tags on a page, it first checks for the Twitter-specific property, and if not present, falls back to the supported Open Graph property." For Guides pages, `og:title` contains the desired text and matches each page's `title` element.

This work is required for the v2 de-risking guide (https://github.com/18F/guides/pull/671) but I'm keeping this change separate from that feature branch because it affects the behavior for all guides, and I'd like to be able to test and (if necessary) revert independently.

## Testing

### Via X post composer

Directly testing the appearance of X cards requires a login to an X account.

- Log in to X.com
- Begin a new post to open the post composer
- Paste in a URL from this PR's build for a page containing a title and description. For example: https://federalist-8bc0b42c-5fd0-4ae8-9366-cd9c265a4446.sites.pages.cloud.gov/preview/18f/guides/drg-v2-remove-twitter-title-tag/methods/decide/service-blueprint/
- The window should show a preview of the card with a title like "Service blueprint | 18F Methods". I've found this to be flaky; when the preview hasn't appeared I've gotten it to work by closing the draft post, refreshing the page, and repeating
- Optionally, post the post and confirm the card's title in your feed

![Screenshot 2024-08-27 154058](https://github.com/user-attachments/assets/9880fda0-fde9-4d8b-b257-e1eca066d3bb)

### Via page source

- Open a page from this PR build as above
- Open the page source
- Confirm that the `header` section no longer contains a `<meta name="twitter:title">` element

## security considerations

No security considerations; this does not expose any additional page data.
