### PR TITLE
Implement Touchpoints feedback survey

### DIFF
--- a/_data/site.yaml
+++ b/_data/site.yaml
@@ -38,6 +38,11 @@ searchgov:
   # If you do not want to present search suggestions, set this value to false.
   suggestions: false
 
+# Touchpoints survey form data, if any. See: https://github.com/GSA/touchpoints/wiki/Delivery-Options
+touchpoints:
+  script: https://touchpoints.app.cloud.gov/touchpoints/7d891616.js
+  button_id: touchpoints-form
+
 ##########################################################################################
 # The values below here are more advanced and should only be
 # changed if you know what they do

--- a/_includes/layouts/base.html
+++ b/_includes/layouts/base.html
@@ -27,6 +27,8 @@ The home page uses wide.html layout, since it extends full width of page
 
       {{ content }}
 
+      {% include "touchpoints-button.html" %}
+      
       {% include "footer.html" %}
 
       {% comment %} Hide SVG Sprites {% endcomment %}

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -28,3 +28,8 @@
     <script async src="https://search.usa.gov/javascripts/remote.loader.js" type="text/javascript"></script>
   {% endif %}
 {% endif %}
+
+{% if site.touchpoints and site.touchpoints.script %}
+  <!-- Touchpoints survey -->
+  <script src="{{ site.touchpoints.script }}" async></script>
+{% endif %}

--- a/_includes/touchpoints-button.html
+++ b/_includes/touchpoints-button.html
@@ -1,0 +1,11 @@
+{% comment %} If a Touchpoints feedback survey is configured, render its custom button. {% endcomment %}
+{% if site.touchpoints and site.touchpoints.script %}
+  {% if site.touchpoints.button_id %}
+    {% assign button_id = site.touchpoints.button_id %}
+  {% else %}
+    {% assign button_id = 'touchpoints-form' %}
+  {% endif %}
+  <div aria-label="Feedback button" role="complementary">
+    <button class="usa-button" id="{{ button_id }}"><span>{% uswds_icon "chat" %}</span>Was this page helpful?</button>
+  </div>
+{% endif %}

--- a/assets/_common/styles/custom-styles.scss
+++ b/assets/_common/styles/custom-styles.scss
@@ -1,3 +1,4 @@
+@use '../../_common/styles/brand-colors' as *;
 @use 'uswds-core' as * ;
 
 $bullet-spacing: 1.25rem;
@@ -202,4 +203,20 @@ h2.heading-md {
 
 .example-user-interview-script code {
   background: yellow;
+}
+
+/* Touchpoints feedback button */
+#touchpoints-form {
+  @include u-font('sans', '3xs');
+  background-color: $brand-color-medium;
+  border-radius: 0.25rem 0.25rem 0 0;
+  bottom: 0;
+  position: fixed;
+  right: 0.75rem;
+  z-index: 9999;
+
+  span .usa-icon {
+    font-size: size('body', 'sm');
+    vertical-align: middle;
+  }
 }

--- a/docs/development.md
+++ b/docs/development.md
@@ -303,6 +303,22 @@ OpenGraph image tags can be configured optionally at a guide level in the [_data
 | `twitter:description` | The description set in the page's [front matter](#top-level). |
 | `twitter:site` | The Twitter handle configured in the [_data/site.yaml](https://github.com/18F/guides/blob/main/_data/site.yaml) file. |
 
+## User feedback forms
+
+The Guides site implements customer feedback collecting using [Touchpoints](https://touchpoints.digital.gov/), a GSA product that provides
+Paperwork Reduction Act-friendly survey forms.
+
+The survey form is defined within the Touchpoints system and managed by the 18F team. It is integrated into every guide page using a modal
+and custom button element and modal, as documented in the [Touchpoints product wiki](https://github.com/GSA/touchpoints/wiki/Delivery-Options#open-a-modal-by-clicking-a-custom-button-element).
+
+The Touchpoints javascript code and the ID of the custom button element are defined within the Touchpoints survey configuration
+and configured in this project in the [_data/site.yaml](https://github.com/18F/guides/blob/main/_data/site.yaml) file.
+
+| configuration key | value |
+|---|---|
+| `touchpoints.script` | The absolute URL of the survey's javascript file. If this value is absent, the modal and button won't be included. |
+| `touchpoints.button_id` | The ID of the button element that opens the survey modal. If this value is absent, the ID defaults to "touchpoints-form". |
+
 ## Managing dependencies
 
 This project uses Github's Dependabot to keep the NPM dependencies up to date.


### PR DESCRIPTION
## Changes proposed in this pull request:

Integrate Touchpoints user feedback surveys into all 18F Guides pages. See the updated [developer docs](https://github.com/18F/guides/pull/723/files#diff-97db29a7915320e63d41d38a0440360a87055ee8ed03757aa263116dbbb4aabe) for details.

Resolves https://github.com/18F/TLC-crew/issues/885.

### Screenshots

#### Feedback button

<img width="1121" alt="Screenshot 2024-09-26 at 9 36 06 AM" src="https://github.com/user-attachments/assets/e919a2d3-37c1-4236-8687-13bfd7eee1c1">

#### Survey modal

<img width="582" alt="Screenshot 2024-09-26 at 9 36 15 AM" src="https://github.com/user-attachments/assets/208d8e72-a7cb-4dda-bf40-71578a930ce7">

#### 

### Approach

The Touchpoints form is integrated via two code sources:

1. Javascript that is fetched from the Touchpoints application and run at page load time.
2. A button element with custom styling within this project's page layout code.

The script URL and the button element ID are both properties of the Touchpoints form configuration and are subject to change, although changes are likely to be infrequent. For maintainability I've defined those values within this project's site configuration file, instead of hardcoding them into our page template source code.

The Touchpoints survey should be able to rely on the Guides site's USWDS styles, but this [USWDS issue](https://github.com/uswds/uswds/issues/5608) causes an apparent race condition which can cause the Touchpoints script not to initialize when the page loads, which breaks the button functionality and form styling. To work around this bug, our survey is configured on the Touchpoints side to provide its own CSS styles, which the script injects into a `style` element on our page when it initializes. I've confirmed that the class names in those styles don't collide with any currently used within this project, and are specific enough to Touchpoints that they are unlikely to cause naming collisions in the future.

## Testing

Manually test the Touchpoints form behavior on the [PR build](https://federalist-8bc0b42c-5fd0-4ae8-9366-cd9c265a4446.sites.pages.cloud.gov/preview/18f/guides/guides-885-touchpoint/):

- Confirm that each guide page includes a sticky "Was this page helpful?" button in the lower-right corner of the page.
- Click the button and confirm it opens an "18F Guides feedback" form in a modal window.
- Fill out the form and click Submit, and confirm the Touchpoints modal shows you a success message. (Note the comment below about multiple submissions not working due to https://github.com/GSA/touchpoints/issues/1643.)
- Ask @nateborr or @ameliaswong to confirm receipt of the feedback within the Touchpoints system.

Manually smoke-test a few different Guides and pages and confirm that the overall styling is still correct.

Review the updated developer docs to confirm they are sufficient to inform contributors about the new functionality.

## security considerations

Minimal. Touchpoints is an established, GSA provided SaaS product.

On the Touchpoints side, sources of form submissions are restricted based on an allowlist of URLs. In our case that is configured to the Guides site and this PR's Federalist build.
