### PR TITLE
Add file download icon to de-risking guide primary nav

### DIFF
--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -32,8 +32,11 @@ manage your navigation system {% endcomment %}
             class="usa-nav__link{% if basedir == linkdir %} usa-current{% endif %}"
             href="{{ nav_item.url | url }}"
             {% if nav_item.download %}download{% endif %}
-            ><span>{{ nav_item.name | escape }}</span></a
-          >
+            ><span>{{ nav_item.name | escape }}</span>
+            {% if nav_item.download %}
+              <span class="download-icon">{% uswds_icon "file_download" %}</span>
+            {% endif %}
+          </a>
         </li>
         {% else %} {% assign nav_id = 'primary-nav-' | append: forloop.index %}
         <li class="usa-nav__primary-item">

--- a/assets/_common/styles/custom-styles.scss
+++ b/assets/_common/styles/custom-styles.scss
@@ -220,3 +220,14 @@ h2.heading-md {
     vertical-align: middle;
   }
 }
+
+/* Primary navigation icons */
+.usa-nav__primary-item .usa-nav__link .download-icon {
+  padding-left: 2px;
+
+  .usa-icon {
+    min-height: 1rem;
+    min-width: 1rem;
+    vertical-align: middle;
+  }
+}

--- a/assets/_common/styles/overrides/extended-header.scss
+++ b/assets/_common/styles/overrides/extended-header.scss
@@ -17,4 +17,10 @@
     border-style: solid;
     border-top: 0;
   }
+
+  /* Position the file download icon in the primary nav */
+  .usa-nav__primary-item .usa-nav__link span.download-icon .usa-icon {
+    display: inline-block;
+    margin-top: 1px;
+  }
 }

--- a/docs/development.md
+++ b/docs/development.md
@@ -133,7 +133,7 @@ agile:
     url: /agile/
 ```
 
-You can add the `download` attribute to a primary navigation link and specify a file name by setting the optional `download` key to `true`.
+If you set the optional `download` key to `true` for a navigation item, it will add the `download` attribute to the link and display a file download icon next to its name.
 
 _Example:_
 ```


### PR DESCRIPTION
## Changes proposed in this pull request:

Display an icon next to download links in the primary navigation. Currently this is used only in the de-risking guide.

Resolves https://github.com/18F/guides/issues/704.

### Approach

When the page is at least 64em wide and the primary nav is shown in the page header, conditionally set a 1-pixel top margin on the icon in order to optically center it. This isn't necessary in narrower screens, when the primary nav moves to the Menu drop-down. This is implemented within the existing media rule for the extended header styles.

## Testing

Manually test the primary nav in [this PR's build](https://federalist-8bc0b42c-5fd0-4ae8-9366-cd9c265a4446.sites.pages.cloud.gov/preview/18f/guides/guides-704-download-icon/derisking-government-tech/).

- Visit any page in the de-risking guide.
- Confirm that the "Download" link shows the USWDS file download icon to its right when the viewport is...
  1. wide enough that the primary nav is shown at the top of the page
  2. narrow enough that the primary nav is shown within the "Menu" dropdown
- Check that all primary links don't include icons, appear correctly, and work as expected.

## security considerations

None. This change uses the existing framework.
