### PR TITLE
#207: Wrap h2 balanced to keep long headings together with their permalinks

### DIFF
--- a/assets/_common/styles/custom-styles.scss
+++ b/assets/_common/styles/custom-styles.scss
@@ -63,8 +63,9 @@ h1, h2, h3, h4, h5, h6 {
   }
 
   h2, h3, h4, h5, h6 {
-      // prevent orphans and not using the Chromium-only "pretty"
+      // prevent orphans and use balance if pretty is not available
       text-wrap: balance;
+      text-wrap: pretty;
   }
 
   h2 {

--- a/assets/_common/styles/custom-styles.scss
+++ b/assets/_common/styles/custom-styles.scss
@@ -64,6 +64,7 @@ h1, h2, h3, h4, h5, h6 {
 
   h2 {
     margin-top: units(5);
+    text-wrap: balance;
     &.page-title {
       margin-top: units(0);
       &.derisking {

--- a/assets/_common/styles/custom-styles.scss
+++ b/assets/_common/styles/custom-styles.scss
@@ -62,9 +62,13 @@ h1, h2, h3, h4, h5, h6 {
     word-wrap: break-word;
   }
 
+  h2, h3, h4, h5, h6 {
+      // prevent orphans and not using the Chromium-only "pretty"
+      text-wrap: balance;
+  }
+
   h2 {
     margin-top: units(5);
-    text-wrap: balance;
     &.page-title {
       margin-top: units(0);
       &.derisking {


### PR DESCRIPTION
#207 asks for a fix to orphaned permalink icons on headings that are a particular length relative to the column width. @beepdotgov suggested `text-wrap: balance` in that ticket and it appears to do what we want.

![Screenshot 2024-10-17 at 11 49 00 AM](https://github.com/user-attachments/assets/af9c476d-8dcf-400b-bb22-8c13d3423801)

(I had some difficulties getting the change to show up in the generated styles-XXXXXXXX.css file, but eventually it did and I think that it will work right in the build after the PR is merged.)

## Changes proposed in this pull request:

- Add `text-wrap: balance` to H2 elements

## security considerations

None because a purely visual change