### PR TITLE
Add link to our Figma card sort template

### DIFF
--- a/content/methods/validate/card-sorting.md
+++ b/content/methods/validate/card-sorting.md
@@ -42,6 +42,14 @@ There are two types of card sorting: open and closed. Most card sorts are perfor
 
 </section>
 
+<section class="method--section method--section--additional-resources" markdown="1">
+
+## Additional resources
+
+- [18F card sort template (Figma)](https://www.figma.com/board/jhPXgKic2ory6wWu27XcDj/18F-Card-Sort-Template)
+
+</section
+
 <section class="method--section method--section--government-considerations" markdown="1" >
 
 ## Considerations for use in government{#con-card-sort}


### PR DESCRIPTION
#711 has a straightforward request to add a link to a card sort template on Figma.

## Changes proposed in this pull request:

- Add the requested link to the template on the card sort method card

## security considerations

None, just adding one link.
