### PR TITLE
Update links which reference archived repo

### DIFF
--- a/content/engineering/languages-runtimes/language-selection.md
+++ b/content/engineering/languages-runtimes/language-selection.md
@@ -27,7 +27,7 @@ subnav:
 
 Many factors should influence how 18F engineers make technology selections for their projects. Here, we discuss recommendations on how to select the _language_ used in your projects. This document doesn't offer hard-and-fast rules, focusing instead on several language aspects which should be balanced against each other. Also, we explicitly note that language selection is ultimately the decision (and responsibility) of the project team. The guidance below is meant to _assist_ your team make this decision.
 
-This is a living document. After looking at [existing tickets](https://github.com/18F/development-guide/issues), [start an issue](https://github.com/18F/development-guide/issues/new) or pull request in GitHub to suggest changes to these standards.
+This is a living document. After looking at [existing tickets](https://github.com/18F/guides/issues), [start an issue](https://github.com/18F/guides/issues/new) or pull request in GitHub to suggest changes to these standards.
 
 ## Our strongest languages
 18F has historically worked in three **primary** languages: JavaScript, Python, and Ruby. While we certainly have a healthy smattering of other odds and ends, these three are our primary strength as indicated by data from past projects, engineer skill sets, and billable hours. These languages are generally a safe bet as we know we can support them and be productive with them.

--- a/content/engineering/languages-runtimes/nodejs.md
+++ b/content/engineering/languages-runtimes/nodejs.md
@@ -33,7 +33,7 @@ subnav:
 * [JavaScript]({{ "/engineering/languages-runtimes/javascript/" | url }})
 
 ## Introduction
-This is a **WORK IN PROGRESS**. Help us make it better by [submitting an issue](https://github.com/18F/development-guide) or joining us in the [#javascript](https://gsa-tts.slack.com/messages/C032KSPPQ) channel!
+This is a **WORK IN PROGRESS**. Help us make it better by [submitting an issue](https://github.com/18F/guides/issues/new) or joining us in the [#javascript](https://gsa-tts.slack.com/messages/C032KSPPQ) channel!
 
 This document is structured by topic; under each, we include “Standards”, “Defaults”, and “Suggestions”.
 

--- a/content/engineering/languages-runtimes/python.md
+++ b/content/engineering/languages-runtimes/python.md
@@ -23,7 +23,7 @@ subnav:
     href: "#type-support"
 ---
 
-This is a **WORK IN PROGRESS**. Help us make it better by [submitting an issue](https://github.com/18F/development-guide) or joining us in the [#python](https://gsa-tts.slack.com/messages/C02ES0C3R) channel!
+This is a **WORK IN PROGRESS**. Help us make it better by [submitting an issue](https://github.com/18F/guides/issues/new) or joining us in the [#python](https://gsa-tts.slack.com/messages/C02ES0C3R) channel!
 
 This document is structured by topic; under each, we include “Standards”, “Defaults”, and “Suggestions”.
 

--- a/content/engineering/languages-runtimes/ruby.md
+++ b/content/engineering/languages-runtimes/ruby.md
@@ -18,7 +18,7 @@ subnav:
   - text: Testing
     href: "#testing"
 ---
-Help us make this section better by [submitting an issue](https://github.com/18F/development-guide) or joining us in the [#ruby](https://18f.slack.com/messages/ruby/) channel!
+Help us make this section better by [submitting an issue](https://github.com/18F/guides/issues/new) or joining us in the [#ruby](https://18f.slack.com/messages/ruby/) channel!
 
 A guide for writing and maintaining Ruby and Rails applications
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update 5 links which point to the archived `development-guides` repo so they point to this repo instead.
- Update 3 links which reference "submitting an issue" so they send the user to the `/issues/new` endpoint on said repo.

## Security considerations

No security considerations as a review of the link's content here should be enough to ensure they are not leading users to an unintended location.
