### PR TITLE
Add new method card for content highlighter testing

### DIFF
--- a/content/methods/validate/content-highlighter-testing.md
+++ b/content/methods/validate/content-highlighter-testing.md
@@ -1,0 +1,49 @@
+---
+title: Content highlighter testing
+description: Find out how to improve your content with content highlighter testing.
+permalink: /methods/validate/content-highlighter-testing/
+layout: layouts/method-card
+tags: methods
+eleventyNavigation:
+  key: methods
+  parent: Validate
+  title: Content highlighter testing
+method:
+  title: Content highlighter testing
+  what: Users highlight text that they think is clear in one color. Then they highlight text they think is confusing in a different color. 
+  why: To understand which words and phrases are achieving their intended purpose. This test can help clarify how to improve the content. 
+  timeRequired: 1-2 hours per test
+  category: validate
+  last_modified_at: example timestamp
+---
+
+## How to do it{#how-content-highlighter}
+
+1. **Select content**: Decide on the content you want to test.
+2. **Select a tool**: You can conduct this test in person, on paper, or online. If conducting the test online, choose an application that allows content highlighting and one that your users are familiar with.
+3. **Define what you’re testing**: Determine what qualities you want to test for. You can ask users to highlight clear content and then confusing content. Or, you can ask users to highlight content that makes them feel confident and then content that makes them feel less confident. It depends on what your goals are. We’ll use clear/confusing for this example.
+4. **Pick the colors**: Assign a color for each quality and explain what the colors mean. For example, “Use the green highlighter for information that is clear. Use the blue highlighter for information that is confusing.”
+5. **Write instructions**: If conducting the test online, prepare instructions that explain how the test will work, what the colors mean, how to highlight text, and how long the test will take.
+6. **Start the test**: Ask the user to read the text and highlight content according to your criteria.
+7. **Discuss**: You can ask users to discuss their highlights during the test. This can be useful for longer pieces of content. Or, you can wait until after the highlighting to discuss. Encourage users to describe why they highlighted passages. For example, “What did you find confusing about that sentence?”
+8. **Analyze results**: What did users think was clear? Confusing? How did the results differ across sessions? Identify priority content improvements based on the results.
+
+<section class="method--section method--section--18f-example" markdown="1" >
+
+## Example from 18F{#ex-content-highlighter}
+
+- **Project**: pra.digital.gov
+- **Problem**: Site content was based on an internal document and not written for a public audience. The content needed to be approved by the general counsel before moving forward.
+- **Highlighter test**: The content was rewritten in plain language. Two attorneys reviewed it for clarity and accuracy using the highlighter method. Both attorneys reviewed the content at the same time, sitting at the same table, with their own copies of the content and colored highlighters. They discussed legal terms and wording with each other and the content strategist. In addition to improving the content, this test allowed us to avoid a later legal review. 
+
+</section>
+
+<section class="method--section method--section--government-considerations" markdown="1" >
+
+## Considerations for use in government{#gov-content-highlighter}
+
+In general, content highlighter testing doesn’t require PRA approval. 
+- Read the [PRA guidance on usability testing from the Office of Information and Regulatory Affairs](https://www.whitehouse.gov/wp-content/uploads/2024/11/PRA-Usability-Testing-Guidance-Memo.pdf)(PDF). 
+- Consult the methods for [recruiting]({{ "/methods/fundamentals/recruiting/" | url }})) and [privacy]({{ "//methods/fundamentals/privacy/" | url }})) for tips on getting input from the public.
+
+</section>

--- a/content/methods/validate/content-highlighter-testing.md
+++ b/content/methods/validate/content-highlighter-testing.md
@@ -44,7 +44,7 @@ method:
 
 In general, content highlighter testing doesn’t require PRA approval. 
 
-- Read the [PRA guidance on usability testing from the Office of Information and Regulatory Affairs](https://www.whitehouse.gov/wp-content/uploads/2024/11/PRA-Usability-Testing-Guidance-Memo.pdf)(PDF).
+- Read the [PRA guidance on usability testing from the Office of Information and Regulatory Affairs](https://www.whitehouse.gov/wp-content/uploads/2024/11/PRA-Usability-Testing-Guidance-Memo.pdf) (PDF).
 - Consult the methods for [recruiting]({{ "/methods/fundamentals/recruiting/" | url }}) and [privacy]({{ "/methods/fundamentals/privacy/" | url }}) for tips on getting input from the public.
 
 </section>

--- a/content/methods/validate/content-highlighter-testing.md
+++ b/content/methods/validate/content-highlighter-testing.md
@@ -40,7 +40,7 @@ method:
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#gov-content-highlighter}
+## Considerations for use in government
 
 In general, content highlighter testing doesn’t require PRA approval. 
 

--- a/content/methods/validate/content-highlighter-testing.md
+++ b/content/methods/validate/content-highlighter-testing.md
@@ -40,7 +40,7 @@ method:
 
 <section class="method--section markdown="1" >
 
-## Considerations for use in government{#gov-content-highlighter}
+## Government considerations{#gov-content-highlighter}
 
 In general, content highlighter testing doesn’t require PRA approval. 
 

--- a/content/methods/validate/content-highlighter-testing.md
+++ b/content/methods/validate/content-highlighter-testing.md
@@ -33,8 +33,8 @@ method:
 ## Example from 18F{#ex-content-highlighter}
 
 - **Project**: [pra.digital.gov](https://pra.digital.gov/)
-- **Problem**: Site content was based on an internal document and not written for a public audience. The content needed to be approved by the general counsel before moving forward.
-- **Highlighter test**: The content was rewritten in plain language. Two attorneys reviewed it for clarity and accuracy using the highlighter method. Both attorneys reviewed the content at the same time, sitting at the same table, with their own copies of the content and colored highlighters. They discussed legal terms and wording with each other and the content strategist. In addition to improving the content, this test allowed us to avoid a later legal review. 
+  - **Problem**: Site content was based on an internal document and not written for a public audience. The content needed to be approved by the general counsel before moving forward.
+  - **Highlighter test**: The content was rewritten in plain language. Two attorneys reviewed it for clarity and accuracy using the highlighter method. Both attorneys reviewed the content at the same time, sitting at the same table, with their own copies of the content and colored highlighters. They discussed legal terms and wording with each other and the content strategist. In addition to improving the content, this test allowed us to avoid a later legal review. 
 
 </section>
 

--- a/content/methods/validate/content-highlighter-testing.md
+++ b/content/methods/validate/content-highlighter-testing.md
@@ -38,9 +38,9 @@ method:
 
 </section>
 
-<section class="method--section method--section--government-considerations" markdown="1" >
+<section class="method--section markdown="1" >
 
-## Considerations for use in government
+## Considerations for use in government{#gov-content-highlighter}
 
 In general, content highlighter testing doesn’t require PRA approval. 
 

--- a/content/methods/validate/content-highlighter-testing.md
+++ b/content/methods/validate/content-highlighter-testing.md
@@ -43,7 +43,7 @@ method:
 ## Considerations for use in government{#gov-content-highlighter}
 
 In general, content highlighter testing doesn’t require PRA approval. 
-- Read the [PRA guidance on usability testing from the Office of Information and Regulatory Affairs](https://www.whitehouse.gov/wp-content/uploads/2024/11/PRA-Usability-Testing-Guidance-Memo.pdf)(PDF). 
+- Read the [PRA guidance on usability testing from the Office of Information and Regulatory Affairs](https://www.whitehouse.gov/wp-content/uploads/2024/11/PRA-Usability-Testing-Guidance-Memo.pdf)(PDF).
 - Consult the methods for [recruiting]({{ "/methods/fundamentals/recruiting/" | url }}) and [privacy]({{ "/methods/fundamentals/privacy/" | url }}) for tips on getting input from the public.
 
 </section>

--- a/content/methods/validate/content-highlighter-testing.md
+++ b/content/methods/validate/content-highlighter-testing.md
@@ -32,7 +32,7 @@ method:
 
 ## Example from 18F{#ex-content-highlighter}
 
-- **Project**: pra.digital.gov
+- **Project**: [pra.digital.gov](https://pra.digital.gov/)
 - **Problem**: Site content was based on an internal document and not written for a public audience. The content needed to be approved by the general counsel before moving forward.
 - **Highlighter test**: The content was rewritten in plain language. Two attorneys reviewed it for clarity and accuracy using the highlighter method. Both attorneys reviewed the content at the same time, sitting at the same table, with their own copies of the content and colored highlighters. They discussed legal terms and wording with each other and the content strategist. In addition to improving the content, this test allowed us to avoid a later legal review. 
 

--- a/content/methods/validate/content-highlighter-testing.md
+++ b/content/methods/validate/content-highlighter-testing.md
@@ -44,6 +44,6 @@ method:
 
 In general, content highlighter testing doesn’t require PRA approval. 
 - Read the [PRA guidance on usability testing from the Office of Information and Regulatory Affairs](https://www.whitehouse.gov/wp-content/uploads/2024/11/PRA-Usability-Testing-Guidance-Memo.pdf)(PDF). 
-- Consult the methods for [recruiting]({{ "/methods/fundamentals/recruiting/" | url }})) and [privacy]({{ "//methods/fundamentals/privacy/" | url }})) for tips on getting input from the public.
+- Consult the methods for [recruiting]({{ "/methods/fundamentals/recruiting/" | url }}) and [privacy]({{ "/methods/fundamentals/privacy/" | url }}) for tips on getting input from the public.
 
 </section>

--- a/content/methods/validate/content-highlighter-testing.md
+++ b/content/methods/validate/content-highlighter-testing.md
@@ -43,6 +43,7 @@ method:
 ## Considerations for use in government{#gov-content-highlighter}
 
 In general, content highlighter testing doesn’t require PRA approval. 
+
 - Read the [PRA guidance on usability testing from the Office of Information and Regulatory Affairs](https://www.whitehouse.gov/wp-content/uploads/2024/11/PRA-Usability-Testing-Guidance-Memo.pdf)(PDF).
 - Consult the methods for [recruiting]({{ "/methods/fundamentals/recruiting/" | url }}) and [privacy]({{ "/methods/fundamentals/privacy/" | url }}) for tips on getting input from the public.
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- Add new method for content highlighter testing
- Updated standard content re: PRA based on latest OIRA guidance. If this language is accepted, I'll make similar changes on other methods that reference PRA.
- I propose we change "Considerations for use in government to "Government considerations" on all cards that have that section. 

[Preview URL](https://federalist-8bc0b42c-5fd0-4ae8-9366-cd9c265a4446.sites.pages.cloud.gov/preview/18f/guides/mr/content-highlight-method-card/methods/validate/content-highlighter-testing/)


