### PR TITLE
 Use sentence case for "Modern software product development"

### DIFF
--- a/content/agile/modern-software-product-development.md
+++ b/content/agile/modern-software-product-development.md
@@ -1,5 +1,5 @@
 ---
-title: Modern Software Product Development
+title: Modern software product development
 permalink: /agile/modern-software-product-development/
 layout: layouts/page
 sidenav: true
@@ -8,7 +8,7 @@ eleventyNavigation:
   key: modern
   parent: agile
   order: 2
-  title: Modern Software Product Development
+  title: Modern software product development
 ---
 
 There are three basic approaches to software development: Waterfall, Agile, and Chaos.


### PR DESCRIPTION
## Changes proposed in this pull request:

- Use sentence case for "Modern software product development"

[URL preview](https://federalist-8bc0b42c-5fd0-4ae8-9366-cd9c265a4446.sites.pages.cloud.gov/preview/18f/guides/agile-guide-minor-edits/agile/modern-software-product-development/)
