### PR TITLE
Method card updates: change "government considerations" heading, remove "time required", fix layout issue

### DIFF
--- a/_includes/methods/method.html
+++ b/_includes/methods/method.html
@@ -17,10 +17,7 @@
         <h1>Phase</h1>
         <p>{{ this_method.category | capitalize }}</p>
       </section>
-      <section class="method--section method--section--time-required">
-        <h1>Time required</h1>
-        <p>{{ this_method.timeRequired }}</p>
-      </section>
+
     </footer>
   </div>
   <div class="method--panel method--panel--back">

--- a/content/methods/decide/affinity-mapping.md
+++ b/content/methods/decide/affinity-mapping.md
@@ -26,7 +26,7 @@ method:
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#consideration-affinity-mapping}
+## Government considerations{#consideration-affinity-mapping}
 
 No PRA implications. This method may use data gathered from members of the public, but does not require their involvement.
 </section>

--- a/content/methods/decide/archetypes.md
+++ b/content/methods/decide/archetypes.md
@@ -49,7 +49,7 @@ Archetypes can be created virtually using any variety of digital whiteboards or 
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Applied in government{#con-personas}
+## Government considerations{#con-personas}
 
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/content/methods/decide/comparative-analysis.md
+++ b/content/methods/decide/comparative-analysis.md
@@ -36,7 +36,7 @@ method:
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#considerations-comparative-analysis}
+## Government considerations{#considerations-comparative-analysis}
 
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/content/methods/decide/content-audit.md
+++ b/content/methods/decide/content-audit.md
@@ -55,7 +55,7 @@ method:
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#con-content-audit}
+## Government considerations{#con-content-audit}
 
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/content/methods/decide/design-hypothesis.md
+++ b/content/methods/decide/design-hypothesis.md
@@ -46,7 +46,7 @@ method:
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#con-design-hypo}
+## Government considerations{#con-design-hypo}
 
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/content/methods/decide/design-principles.md
+++ b/content/methods/decide/design-principles.md
@@ -37,7 +37,7 @@ method:
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#con-design-principals}
+## Government considerations{#con-design-principals}
 
 No PRA implications. Generally, no information is collected from members of the public. Even when stakeholders are members of the public, the PRA explicitly exempts direct observation and non-standardized conversation (e.g., not a survey), 5 CFR 1320.3(h)3. See the methods for
 [Recruiting]({{ "/methods/fundamentals/recruiting/" | url }}) and [Privacy]({{ "/methods/fundamentals/privacy/" | url }}) for more tips on taking input from the public.

--- a/content/methods/decide/interface-audit.md
+++ b/content/methods/decide/interface-audit.md
@@ -38,7 +38,7 @@ An interface audit can be conducted by an individual or in a group setting. Eith
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Applied in government research{#app-inter-audit}
+## Government considerations{#app-inter-audit}
 
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/content/methods/decide/journey-mapping.md
+++ b/content/methods/decide/journey-mapping.md
@@ -40,7 +40,7 @@ method:
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#con-journey-mapping}
+## Government considerations{#con-journey-mapping}
 
 No PRA implications. The PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3. See the methods for
 [Recruiting]({{ "/methods/fundamentals/recruiting/" | url }}) and [Privacy]({{ "/methods/fundamentals/privacy/" | url }}) for more tips on taking input from the public.

--- a/content/methods/decide/mental-modeling.md
+++ b/content/methods/decide/mental-modeling.md
@@ -27,7 +27,7 @@ method:
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#con-mental-model}
+## Government considerations{#con-mental-model}
 
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/content/methods/decide/personas.md
+++ b/content/methods/decide/personas.md
@@ -44,7 +44,7 @@ method:
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#con-personas}
+## Government considerations{#con-personas}
 
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/content/methods/decide/qualitative-data-analysis.md
+++ b/content/methods/decide/qualitative-data-analysis.md
@@ -39,7 +39,7 @@ Common for multiple team members to break off to take a pass at sorting data for
 <section class="method--section method--section--government-considerations" markdown="1" >
 
 
-## Considerations for use in government{#con-personas}
+## Government considerations{#con-personas}
 
 When using qualitative data, remove any personally identifiable information (PII) from your documents before sharing.
 </section>

--- a/content/methods/decide/service-blueprint.md
+++ b/content/methods/decide/service-blueprint.md
@@ -41,7 +41,7 @@ method:
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#con-service}
+## Government considerations{#con-service}
 
 No PRA implications. No information is collected directly from members of the public.
 

--- a/content/methods/decide/site-mapping.md
+++ b/content/methods/decide/site-mapping.md
@@ -27,7 +27,7 @@ method:
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#con-site-mapping}
+## Government considerations{#con-site-mapping}
 
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/content/methods/decide/storyboarding.md
+++ b/content/methods/decide/storyboarding.md
@@ -28,7 +28,7 @@ method:
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#con-storyboard}
+## Government considerations{#con-storyboard}
 
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/content/methods/decide/style-tiles.md
+++ b/content/methods/decide/style-tiles.md
@@ -27,7 +27,7 @@ method:
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#con-style-tiles}
+## Government considerations{#con-style-tiles}
 
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/content/methods/decide/task-flow-analysis.md
+++ b/content/methods/decide/task-flow-analysis.md
@@ -36,7 +36,7 @@ method:
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#con-task-flow}
+## Government considerations{#con-task-flow}
 
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/content/methods/decide/user-scenarios.md
+++ b/content/methods/decide/user-scenarios.md
@@ -44,7 +44,7 @@ method:
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#con-user-scenario}
+## Government considerations{#con-user-scenario}
 
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/content/methods/decide/user-stories.md
+++ b/content/methods/decide/user-stories.md
@@ -49,7 +49,7 @@ method:
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#con-personas}
+## Government considerations{#con-personas}
 
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/content/methods/discover/cognitive-walkthrough.md
+++ b/content/methods/discover/cognitive-walkthrough.md
@@ -29,7 +29,7 @@ method:
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#considerations-cog-walkthrough}
+## Government considerations{#considerations-cog-walkthrough}
 
 No PRA implications. The PRA explicitly exempts direct observation and non-standardized conversation (e.g., not a survey) that a cognitive walkthrough entails, 5 CFR 1320.3(h)3.
 

--- a/content/methods/discover/contextual-inquiry.md
+++ b/content/methods/discover/contextual-inquiry.md
@@ -43,7 +43,7 @@ A pair of 18F team members visited two Department of Labor/Wage Hour Division in
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#con-contextual-inquiry}
+## Government considerations{#con-contextual-inquiry}
 
 No PRA implications, if done properly. Contextual interviews should be non-standardized, conversational, and based on observation. The PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3. See the methods for
 [Recruiting]({{ "/methods/fundamentals/recruiting/" | url }}) and [Privacy]({{ "/methods/fundamentals/privacy/" | url }}) for more tips on taking input from the public.

--- a/content/methods/discover/design-studio.md
+++ b/content/methods/discover/design-studio.md
@@ -38,7 +38,7 @@ method:
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#con-design-studio}
+## Government considerations{#con-design-studio}
 
 No PRA implications. If conducted with nine or fewer members of the public, the PRA does not apply, 5 CFR 1320.5(c)4. If participants are employees, the PRA does not apply.
 </section>

--- a/content/methods/discover/dot-voting.md
+++ b/content/methods/discover/dot-voting.md
@@ -32,7 +32,7 @@ method:
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#con-dot-voting}
+## Government considerations{#con-dot-voting}
 
 No PRA implications: dot voting falls under “direct observation”, which is explicitly exempt from the PRA, 5 CFR 1320(h)3. See the methods for [Recruiting]({{ "/methods/fundamentals/recruiting/" | url }}) and [Privacy]({{ "/methods/fundamentals/privacy/" | url }}) for more tips on taking input from the public.
 </section>

--- a/content/methods/discover/five-whys.md
+++ b/content/methods/discover/five-whys.md
@@ -41,7 +41,7 @@ After getting to a root cause, frame or reframe your problem solving approach to
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#con-five-whys}
+## Government considerations{#con-five-whys}
 
 No PRA implications. No information is collected from members of the public.
 

--- a/content/methods/discover/heuristic-evaluation.md
+++ b/content/methods/discover/heuristic-evaluation.md
@@ -42,7 +42,7 @@ method:
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#con-heuristic-eval}
+## Government considerations{#con-heuristic-eval}
 
-No PRA Implications, as heuristic evaluations usually include a small number of evaluators. If conducted with nine or fewer members of the public, the PRA does not apply, 5 CFR 1320.5(c)4. If participants are employees, the PRA does not apply. See the methods for [Recruiting]({{ "/methods/fundamentals/recruiting/" | url }}) and [Privacy]({{ "/methods/fundamentals/privacy/" | url }}) for more tips on taking input from the public.
+No PRA implications, as heuristic evaluations usually include a small number of evaluators. If conducted with nine or fewer members of the public, the PRA does not apply, 5 CFR 1320.5(c)4. If participants are federal employees, the PRA does not apply. See the methods for [Recruiting]({{ "/methods/fundamentals/recruiting/" | url }}) and [Privacy]({{ "/methods/fundamentals/privacy/" | url }}) for more tips on taking input from the public.
 </section>

--- a/content/methods/discover/hopes-and-fears.md
+++ b/content/methods/discover/hopes-and-fears.md
@@ -40,7 +40,7 @@ This format can be adapted to include other categories. For example, asking part
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#con-hopes-fears}
+## Government considerations{#con-hopes-fears}
 
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/content/methods/discover/kj-method.md
+++ b/content/methods/discover/kj-method.md
@@ -36,6 +36,6 @@ method:
 18F conducted this exercise with 20 Federal Election Commission staff members to define priorities around conflicting requests. We used this method to get data from staff (not the decision makers) about what they saw as the most pressing needs. We synthesized and presented the data back to the decision makers.
 </section>
 
-## Considerations for use in government{#con-kj}
+## Government considerations{#con-kj}
 
 At 18F, KJ participants are almost always federal employees. If there is any chance your KJ workshop could include participants who are not federal employees, consult OMB guidance on the Paperwork Reduction Act and the Privacy Act. Your agency’s Office of General Counsel, and perhaps OIRA desk officers, also can ensure you are following the laws and regulations applicable to federal agencies.

--- a/content/methods/discover/lean-coffee.md
+++ b/content/methods/discover/lean-coffee.md
@@ -38,7 +38,7 @@ At 18F, Lean coffee is often used to facilitate community of practice meetings a
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#con-lean-coffee}
+## Government considerations{#con-lean-coffee}
 
 No PRA implications. No information is collected from members of the public.
 

--- a/content/methods/discover/stakeholder-and-user-interviews.md
+++ b/content/methods/discover/stakeholder-and-user-interviews.md
@@ -39,7 +39,7 @@ method:
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#con-stake}
+## Government considerations{#con-stake}
 
 No PRA implications. The PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3. See the methods for [Recruiting]({{ "/methods/fundamentals/recruiting/" | url }}) and [Privacy]({{ "/methods/fundamentals/privacy/" | url }}) for more tips on taking input from the public.
 </section>

--- a/content/methods/discover/stakeholder-influence-mapping.md
+++ b/content/methods/discover/stakeholder-influence-mapping.md
@@ -28,7 +28,7 @@ method:
 
 <section class="method--section method--section--18f-example" markdown="1" >
 
-## Considerations for use in government{#con-stake-i}
+## Government considerations{#con-stake-i}
 
 No PRA implications. No information is collected from members of the public.
 

--- a/content/methods/discover/system-map.md
+++ b/content/methods/discover/system-map.md
@@ -42,9 +42,9 @@ method:
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#con-system-map}
+## Government considerations{#con-system-map}
 
 No PRA implications. Even when users are present, the PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3.
-If you are not working with government employees, you will need to observe standard precautions for archiving personally identifiable information.
+If you are not working with federal government employees, you will need to observe standard precautions for archiving personally identifiable information.
 
 </section>

--- a/content/methods/fundamentals/compensation.md
+++ b/content/methods/fundamentals/compensation.md
@@ -34,11 +34,11 @@ method:
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#considerations-compensation}
+## Government considerations{#considerations-compensation}
 
 No PRA implications. Even when users are present, the PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3.
 
-If you are not working with government employees, you will need to observe standard precautions for archiving personally identifiable information.
+If you are not working with federal government employees, you will need to observe standard precautions for archiving personally identifiable information.
 
 </section>
 

--- a/content/methods/fundamentals/privacy.md
+++ b/content/methods/fundamentals/privacy.md
@@ -35,7 +35,7 @@ method:
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#con-privacy}
+## Government considerations{#con-privacy}
 
 The government’s use of information about people is subject to a number of laws and policies, including: <a href="https://www.justice.gov/opcl/overview-privacy-act-1974-2020-edition" class="usa-link">the Privacy Act of 1974</a>, the Federal Information Security Management Act of 2002, and the eGovernment Act of 2002.
 

--- a/content/methods/fundamentals/recruiting.md
+++ b/content/methods/fundamentals/recruiting.md
@@ -42,7 +42,7 @@ method:
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#con-recruiting}
+## Government considerations{#con-recruiting}
 
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/content/methods/make/design-pattern-library.md
+++ b/content/methods/make/design-pattern-library.md
@@ -28,7 +28,7 @@ method:
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#con-design-pat-lib}
+## Government considerations{#con-design-pat-lib}
 
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/content/methods/make/prototyping.md
+++ b/content/methods/make/prototyping.md
@@ -29,7 +29,7 @@ method:
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#con-prototype}
+## Government considerations{#con-prototype}
 
 No PRA implications. The PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3. See the methods for
 [Recruiting]({{ "/methods/fundamentals/recruiting/" | url }}) and [Privacy]({{ "/methods/fundamentals/privacy/" | url }}) for more tips on taking input from the public.

--- a/content/methods/make/wireframing.md
+++ b/content/methods/make/wireframing.md
@@ -27,7 +27,7 @@ method:
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#con-wireframe}
+## Government considerations{#con-wireframe}
 
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/content/methods/validate/card-sorting.md
+++ b/content/methods/validate/card-sorting.md
@@ -48,7 +48,7 @@ There are two types of card sorting: open and closed. Most card sorts are perfor
 
 - [18F card sort template (Figma)](https://www.figma.com/board/jhPXgKic2ory6wWu27XcDj/18F-Card-Sort-Template)
 
-</section
+</section>
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 

--- a/content/methods/validate/card-sorting.md
+++ b/content/methods/validate/card-sorting.md
@@ -52,7 +52,7 @@ There are two types of card sorting: open and closed. Most card sorts are perfor
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#con-card-sort}
+## Government considerations{#con-card-sort}
 
 No PRA implications if done as directly moderated sessions. The PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3.
 </section>

--- a/content/methods/validate/content-highlighter-testing.md
+++ b/content/methods/validate/content-highlighter-testing.md
@@ -40,7 +40,7 @@ method:
 
 </section>
 
-<section class="method--section" markdown="1" >
+<section class="method--section method--section--18f-example" markdown="1" >
 
 ## Government considerations{#gov-content-highlighter}
 

--- a/content/methods/validate/content-highlighter-testing.md
+++ b/content/methods/validate/content-highlighter-testing.md
@@ -38,7 +38,7 @@ method:
 
 </section>
 
-<section class="method--section markdown="1" >
+<section class="method--section" markdown="1" >
 
 ## Government considerations{#gov-content-highlighter}
 

--- a/content/methods/validate/content-highlighter-testing.md
+++ b/content/methods/validate/content-highlighter-testing.md
@@ -40,13 +40,12 @@ method:
 
 </section>
 
-<section class="method--section method--section--18f-example" markdown="1" >
+<section class="method--section method--section--government-considerations" markdown="1" >
 
 ## Government considerations{#gov-content-highlighter}
 
 In general, content highlighter testing doesn’t require PRA approval. 
 
-- Read the [PRA guidance on usability testing from the Office of Information and Regulatory Affairs](https://www.whitehouse.gov/wp-content/uploads/2024/11/PRA-Usability-Testing-Guidance-Memo.pdf) (PDF).
-- Consult the methods for [recruiting]({{ "/methods/fundamentals/recruiting/" | url }}) and [privacy]({{ "/methods/fundamentals/privacy/" | url }}) for tips on getting input from the public.
+Read the [PRA guidance on usability testing from the Office of Information and Regulatory Affairs](https://www.whitehouse.gov/wp-content/uploads/2024/11/PRA-Usability-Testing-Guidance-Memo.pdf) (PDF). Consult the methods for [recruiting]({{ "/methods/fundamentals/recruiting/" | url }}) and [privacy]({{ "/methods/fundamentals/privacy/" | url }}) for tips on getting input from the public.
 
 </section>

--- a/content/methods/validate/content-highlighter-testing.md
+++ b/content/methods/validate/content-highlighter-testing.md
@@ -2,6 +2,8 @@
 title: Content highlighter testing
 description: Find out how to improve your content with content highlighter testing.
 permalink: /methods/validate/content-highlighter-testing/
+redirect_from:
+  - content-highlighter-testing/
 layout: layouts/method-card
 tags: methods
 eleventyNavigation:

--- a/content/methods/validate/metrics.md
+++ b/content/methods/validate/metrics.md
@@ -44,7 +44,7 @@ method:
 
 ## Government considerations{#con-metrics}
 
-Surveys of more than nine people require PRA approval. Learn more at [pra.digital.gov](pra.digital.gov). Direct observation and non-standardized conversations like semi-structured [interviews]({{ "/methods/discover/stakeholder-and-user-interviews/" | url }})) are not subject to PRA.
+Surveys of more than nine people require PRA approval. Learn more at [pra.digital.gov](https://pra.digital.gov). Direct observation and non-standardized conversations like semi-structured [interviews]({{ "/methods/discover/stakeholder-and-user-interviews/" | url }})) are not subject to PRA.
 
 Your prototype may not be the only effort being tested. People may be overwhelmed by the amount of data they’re asked to provide. Finding metrics that can be automatically collected can help relieve this burden.
 

--- a/content/methods/validate/metrics.md
+++ b/content/methods/validate/metrics.md
@@ -42,9 +42,9 @@ method:
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#con-metrics}
+## Government considerations{#con-metrics}
 
-Surveys of more than 9 people require PRA approval. Learn more at PRA.Digital.gov. Direct observation and non-standardized conversations like semi-structured [interviews]({{ "/methods/discover/stakeholder-and-user-interviews/" | url }})) are not subject to PRA.
+Surveys of more than nine people require PRA approval. Learn more at [pra.digital.gov](pra.digital.gov). Direct observation and non-standardized conversations like semi-structured [interviews]({{ "/methods/discover/stakeholder-and-user-interviews/" | url }})) are not subject to PRA.
 
 Your prototype may not be the only effort being tested. People may be overwhelmed by the amount of data they’re asked to provide. Finding metrics that can be automatically collected can help relieve this burden.
 

--- a/content/methods/validate/multivariate-testing.md
+++ b/content/methods/validate/multivariate-testing.md
@@ -29,8 +29,8 @@ method:
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#con-multivariate}
+## Government considerations{#con-multivariate}
 
-No PRA implications. No one asks the users questions, so the PRA does not apply. See the methods for
+No PRA implications. The users are not being asked questions, so the PRA does not apply. See the methods for
 [Recruiting]({{ "/methods/fundamentals/recruiting/" | url }}) and [Privacy]({{ "/methods/fundamentals/privacy/" | url }}) for more tips on taking input from the public.
 </section>

--- a/content/methods/validate/usability-testing.md
+++ b/content/methods/validate/usability-testing.md
@@ -52,7 +52,7 @@ main
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government
+## Government considerations
 
 No PRA implications. First, any given usability test should involve nine or fewer users. Additionally, the PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3. It also specifically excludes tests of knowledge or aptitude, 5 CFR 1320.3(h)7, which is essentially what a usability test tests. See the methods for
 [Recruiting]({{ "/methods/fundamentals/recruiting/" | url }}) and [Privacy]({{ "/methods/fundamentals/privacy/" | url }}) for more tips on taking input from the public.

--- a/content/methods/validate/visual-preference-testing.md
+++ b/content/methods/validate/visual-preference-testing.md
@@ -32,7 +32,7 @@ method:
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Considerations for use in government{#con-visual-preference}
+## Government considerations{#con-visual-preference}
 
 No PRA implications. The PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3. See the methods for
 [Recruiting]({{ "/methods/fundamentals/recruiting/" | url }}) and [Privacy]({{ "/methods/fundamentals/privacy/" | url }}) for more tips on taking input from the public.


### PR DESCRIPTION
## Changes proposed in this pull request:

- Edited the heading so it's a bit shorter and won't wrap as often: "Considerations for use in government" to "Government considerations"
- Fixed layout issue for display of all "validate" cards (due to missing closing tag in the first card)
- Remove "Time required" info from displaying on the cards. This was done by removing that field from method.html. The information about the time required still exists in the front matter of the individual method cards. 

Note: Changes to the PRA text under "Government considerations" will be proposed in another PR.


[Preview URL](https://federalist-8bc0b42c-5fd0-4ae8-9366-cd9c265a4446.sites.pages.cloud.gov/preview/18f/guides/mr/edit-gov-considerations-heading/methods/discover/cognitive-walkthrough/)