### PR TITLE
Remove outdated link

### DIFF
--- a/content/methods/decide/user-scenarios.md
+++ b/content/methods/decide/user-scenarios.md
@@ -34,13 +34,6 @@ method:
 1. Share the user scenarios that you’ve written with the user group (and other relevant team members) for validation, feedback, and refinement.
 1. Examine your product, service, or website in light of these user scenarios and identify opportunities to make adjustments that would improve users’ experiences.
 
-<section class="method--section method--section--additional-resources" markdown="1">
-
-## Additional resources{#add-user-scenario}
-
-- [Scenarios — Usability.gov](https://www.usability.gov/how-to-and-tools/methods/scenarios.html){.usa-link .usa-link--external}
-
-</section>
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 


### PR DESCRIPTION
## Changes proposed in this pull request: 

Copied change from https://github.com/18F/guides/pull/649 to see if checks would move forward (as they didn't with the previous PR). cc: @makaylahipke

Removed broken link to Usability.gov and "Additional resources" subheading.

Changes proposed in this pull request:
Usability.gov is now offline and redirecting to a topic page on digital.gov.
Suggest removing this link and the associated subheading since it no longer leads to relevant content.