### PR TITLE
Update 18F peeps to 18F Folks, updates to copy on the brand images page

### DIFF
--- a/content/brand/images.md
+++ b/content/brand/images.md
@@ -11,11 +11,13 @@ eleventyNavigation:
   title: Images
 ---
 ## Representing humans
-In order to offer more diverse and expressive ways to represent humans, we created a custom set of Open Peeps based on [the work of Pablo Stanley](https://www.openpeeps.com/). These are great for showing emotion and to represent anonymous user groups.
+To represent a more diverse spectrum of human experiences, we’ve created an illustration library called *18F Folks*. 
+
+*18F Folks* is based on Pablo Stanley’s open-source library [Open Peeps](https://www.openpeeps.com/). These are great for showing emotion and to represent anonymous user groups.
 
 These are available to GSA staff in two formats:
-* Via the [starter deck](https://docs.google.com/presentation/d/1fAzoUwkfKAS2hy4YkqjHLqSQa_rvqiUyFpgACq6tRpY/edit#slide=id.g2efd29ee28c_0_0), which includes several character sets and a range of emotions as well as guidance on different ways to represent humans.
-* Via the [full Figma library](https://www.figma.com/design/sA9t0Msi5Ycvx5ITVMJylU/18F_Open_Peeps_Mainfile?node-id=2328-21896&t=qWFSkRL1ga6yHdnO-0) for designers.
+* [Starter deck](https://docs.google.com/presentation/d/1fAzoUwkfKAS2hy4YkqjHLqSQa_rvqiUyFpgACq6tRpY/edit#slide=id.g2efd29ee28c_0_0), which includes several character sets and a range of emotions as well as guidance on different ways to represent humans.
+* [Full Figma library](https://www.figma.com/design/sA9t0Msi5Ycvx5ITVMJylU/18F_Open_Peeps_Mainfile?node-id=2328-21896&t=qWFSkRL1ga6yHdnO-0) for designers.
 
 {% image_with_class "assets/brand/img/open_peeps_splash.png" "" "" %}
 
@@ -26,8 +28,8 @@ A collection of images containing the 18F logo that can be used as virtual backg
 
 [Download virtual backgrounds]({{ "/assets/brand/dist/18F_VideoBackgrounds.zip" | url }}){.usa-button}
 
-## Desktop Art
-A variety of wallpaper images for MacBooks and Apple Displays.
+## Desktop art
+A variety of wallpaper images for MacBooks and Apple displays.
 
 {% image_with_class "assets/brand/img/18FDesktop-Preview.png" "" "" %}
 


### PR DESCRIPTION
This PR updates the name of 18F peeps to 18F Folks and updates copy on the page. Note that this PR supersedes #722 – It is a duplicate of the work but with a single signed commit (The original PR had missing signed commits and squashing was difficult due to the time gap and interweaving commits). I have done this manually by copy-pasting the text changes. 

Original Authors:
@mitogi 
@michelle-rago 

