### PR TITLE
Fix malformed TODO selector in pa11y config

### DIFF
--- a/.pa11yci.js
+++ b/.pa11yci.js
@@ -5,6 +5,6 @@ module.exports = {
     runners: ["htmlcs"],
     // ignore iframes because we don't use them and DAP inserts an iframe
     // that causes intermittent pa11y errors
-    hideElements: "iframe, div[style*='display: none;'], [data-pa11y-ignore], a[href*='/TODO/"
+    hideElements: "iframe, div[style*='display: none;'], [data-pa11y-ignore], a[href*='/TODO/']"
   }
 }


### PR DESCRIPTION
Fixes #179.\n\nThe selector in `.pa11yci.js` was missing the closing quote and bracket for `a[href*='/TODO/']`, which made the config malformed.\n\nI verified the file parses with Node and that the updated selector is loaded from the exported config.