### PR TITLE
Fix #712: make guide tables scroll on narrow layouts

### DIFF
--- a/assets/_common/styles/custom-styles.scss
+++ b/assets/_common/styles/custom-styles.scss
@@ -62,6 +62,14 @@ h1, h2, h3, h4, h5, h6 {
     word-wrap: break-word;
   }
 
+  table {
+    display: block;
+    max-width: 100%;
+    min-width: 100%;
+    overflow-x: auto;
+    width: max-content;
+  }
+
   h2, h3, h4, h5, h6 {
       // prevent orphans and use balance if pretty is not available
       text-wrap: balance;


### PR DESCRIPTION
Fixes #712

Added a small table style override in .usa-prose so table content can scroll horizontally when the content is wider than the page.

What this does:
- keeps tables at least as wide as their container (min-width: 100%)
- allows wider tables to keep their natural width (width: max-content)
- enables horizontal scrolling on the table itself (overflow-x: auto)

This avoids clipped table content on narrow desktop layouts while preserving existing table markup.

Verification:
- npm run build